### PR TITLE
added NVDEC data in jtop 

### DIFF
--- a/jtop/__main__.py
+++ b/jtop/__main__.py
@@ -141,10 +141,10 @@ def main():
             # - GUI mode
             if args.server:
                 while True:
-                    # Read tegra stats
-                    stat = jetson.stats
+                    # Read tegra nvpmodel
+                    print(jetson.nvpmodel)
                     # TODO: Convert print to server post
-                    print(stat)
+                    print(jetson.stats)
                     # Sleep before send new stat
                     time.sleep(1)
             else:

--- a/jtop/jtop.py
+++ b/jtop/jtop.py
@@ -67,14 +67,14 @@ def get_nvpmodel():
     # Read nvpmodel to know the status of the board
     try:
         nvpmodel_p = sp.Popen(['nvpmodel', '-q'], stdout=sp.PIPE)
-        query = nvpmodel_p.communicate()[0]
+        out, _ = nvpmodel_p.communicate()
         # Log value
-        logger.debug('nvqmodel status %s', query)
+        logger.debug('nvqmodel status %s', out)
         # Decode lines and split
-        lines = query.decode("utf-8").split("\n")
+        lines = out.decode("utf-8").split("\n")
         return {'name': lines[0].split(": ")[1], 'mode': int(lines[1])}
-    except Exception:
-        logger.error("Exception occurred", exc_info=True)
+    except OSError as e:
+        logger.info("NVPModel Exception occurred {}".format(e), exc_info=True)
         return {}
 
 

--- a/jtop/jtop.py
+++ b/jtop/jtop.py
@@ -496,7 +496,7 @@ class Tegrastats(Thread):
                 # NVDEC Y
                 # NVDEC is the video hardware decoding engine.
                 # Shown only when hardware decoder / encoder engine is used.
-                # NDVEC frequency in MHz
+                # NVDEC frequency in MHz
                 jetsonstats['NVDEC'] = float(other_values[idx+1])
                 idx += 1
             else:

--- a/jtop/jtop.py
+++ b/jtop/jtop.py
@@ -492,6 +492,13 @@ class Tegrastats(Thread):
                 temp['text'] = value
                 # Store temperature value
                 self.temperatures[name] = temp
+            elif 'NVDEC' in data:
+                # NVDEC Y
+                # NVDEC is the video hardware decoding engine.
+                # Shown only when hardware decoder / encoder engine is used.
+                # NDVEC frequency in MHz
+                jetsonstats['NVDEC'] = float(other_values[idx+1])
+                idx += 1
             else:
                 # [VDD_name] X/Y
                 # X = Current power consumption in milliwatts.

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class PostInstallCommand(install):
 # Configuration setup module
 setup(
     name="jetson-stats",
-    version="1.6.10",
+    version="1.6.11",
     author="Raffaello Bonghi",
     author_email="raffaello@rnext.it",
     description="Interactive system-monitor process viewer for NVIDIA Jetson Nano, AGX Xavier, TX2, TX1",


### PR DESCRIPTION
NVDEC (frequency in MHz) is the video hardware decoding engine.
It is shown only when hardware decoder / encoder engine is used.
For example, when I try visionworks demo like nvx_demo_feature_tracker provided by NVidia, jtop stops with an error below.
=====
Exception in thread Thread-1:
Traceback (most recent call last):
File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
self.run()
File "/usr/local/lib/python2.7/dist-packages/jtop/jtop.py", line 222, in run
self._jetsonstats = self.decode(tegrastats_data)
File "/usr/local/lib/python2.7/dist-packages/jtop/jtop.py", line 510, in decode
                             volt['average'].append(float(value[1]))
                                                                    IndexError: list index out of range
=====

The output of tegrastats command is below. (before and after)
=====
RAM 1446/3957MB (lfb 458x4MB) IRAM 0/252kB(lfb 252kB) CPU [17%@1428,11%@1428,21%@1428,12%@1428] EMC_FREQ 2%@1600 GR3D_FREQ 0%@76 APE 25 PLL@20.5C CPU@24.5C PMIC@100C GPU@21C AO@29.5C thermal@22.25C POM_5V_IN 2830/1483 POM_5V_GPU 41/31 POM_5V_CPU 943/206

RAM 1462/3957MB (lfb 457x4MB) IRAM 0/252kB(lfb 252kB) CPU [43%@1036,44%@1036,36%@1036,34%@1036] EMC_FREQ 6%@1600 GR3D_FREQ 51%@307 NVDEC 192 APE 25 PLL@20.5C CPU@24.5C PMIC@100C GPU@22C AO@29.5C thermal@22.75C POM_5V_IN 3353/1616 POM_5V_GPU 450/61 POM_5V_CPU 613/235
=====

I tested on Jetson Nano with JetPack4.2.
