### PR TITLE
feat: add --host and --port arguments in examples/jtop_server.py

### DIFF
--- a/examples/jtop_server.py
+++ b/examples/jtop_server.py
@@ -49,22 +49,22 @@ if __name__ == "__main__":
     print("Simple Tegrastats server")
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect((args.host, args.port))
+    sock.bind((args.host, args.port))
     print("Open server jtop to {}:{}".format(args.host, args.port))
-    # Wait socket request
-    sock.listen()
-    conn, addr = sock.accept()
-    print("Connected to {}".format(conn))
+    sock.listen(1)
 
     with jtop() as jetson:
         try:
             while True:
+                # Wait socket request
+                conn, addr = sock.accept()
+                print("Connected to {}".format(conn))
                 # Read and convert in JSON the jetson stats
                 stats = json.dumps(jetson.stats)
                 # Send by socket
                 conn.send(stats.encode())
-                # Sleep before send new stat
-                time.sleep(1)
+                # Close connection
+                conn.close()
         except Exception:
             sock.close()
 # EOF

--- a/examples/jtop_server.py
+++ b/examples/jtop_server.py
@@ -29,7 +29,6 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from jtop import jtop
-import time
 import socket
 import json
 import argparse

--- a/examples/jtop_server.py
+++ b/examples/jtop_server.py
@@ -65,10 +65,7 @@ if __name__ == "__main__":
                 stats = json.dumps(jetson.stats)
                 # Send by socket
                 if args.http:
-                    conn.send("HTTP/1.1 200 OK\n"
-                            +"Content-Type: application/json\n"
-                            +"\n"
-                            +stats.encode())
+                    conn.send("HTTP/1.1 200 OK\nContent-Type: application/json\n\n" + stats.encode())
                 else:
                     conn.send(stats.encode())
                 # Close connection

--- a/examples/jtop_server.py
+++ b/examples/jtop_server.py
@@ -32,17 +32,25 @@ from jtop import jtop
 import time
 import socket
 import json
+import argparse
 
-HOST = '127.0.0.1'  # Standard loopback interface address (localhost)
-PORT = 65432        # Port to listen on (non-privileged ports are > 1023)
+parser = argparse.ArgumentParser(description='Simple Tegrastats server.')
+
+# Standard loopback interface address (localhost)
+parser.add_argument('--host', action="store", dest="host", default="127.0.0.1")
+
+# Port to listen on (non-privileged ports are > 1023)
+parser.add_argument('--port', action="store", dest="port", type=int, default=65432)
+
+args = parser.parse_args()
 
 if __name__ == "__main__":
 
     print("Simple Tegrastats server")
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect((HOST, PORT))
-    print("Open server jtop to {}:{}".format(HOST, PORT))
+    sock.connect((args.host, args.port))
+    print("Open server jtop to {}:{}".format(args.host, args.port))
     # Wait socket request
     sock.listen()
     conn, addr = sock.accept()

--- a/examples/jtop_server.py
+++ b/examples/jtop_server.py
@@ -41,6 +41,9 @@ parser.add_argument('--host', action="store", dest="host", default="127.0.0.1")
 # Port to listen on (non-privileged ports are > 1023)
 parser.add_argument('--port', action="store", dest="port", type=int, default=65432)
 
+# Optional argument to return message in a valid HTTP response
+parser.add_argument('--http', action="store_true")
+
 args = parser.parse_args()
 
 if __name__ == "__main__":
@@ -61,7 +64,13 @@ if __name__ == "__main__":
                 # Read and convert in JSON the jetson stats
                 stats = json.dumps(jetson.stats)
                 # Send by socket
-                conn.send(stats.encode())
+                if args.http:
+                    conn.send("HTTP/1.1 200 OK\n"
+                            +"Content-Type: application/json\n"
+                            +"\n"
+                            +stats.encode())
+                else:
+                    conn.send(stats.encode())
                 # Close connection
                 conn.close()
         except Exception:


### PR DESCRIPTION
These arguments would help to quickly deploy this script.

Default values still are `127.0.0.1` for `host` and `65432` for `port`.