### PR TITLE
fix: check for fans attribute

### DIFF
--- a/examples/quick_read.py
+++ b/examples/quick_read.py
@@ -42,7 +42,8 @@ if __name__ == "__main__":
             # Status disk
             print(jetson.disk)
             # Status fans
-            print(jetson.fans)
+            if hasattr(jetson, 'fans'):
+                print(jetson.fans)
             # uptime
             print(jetson.uptime)
             # nvpmodel


### PR DESCRIPTION
this line crashes the script on my install.

```
Simple Tegrastats reader
{'TEMP': {u'AO': 44.5, u'PMIC': 100.0, u'thermal': 37.75, u'GPU': 37.0, u'PLL': 35.0, u'CPU': 38.5}, u'EMC': {'val': 0}, 'RAM': {'use': 1794, 'unit': u'M', 'tot': 3957, 'lfb': {'nblock': 247, 'unit': u'M', 'size': 4}}, 'VOLT': {u'POM_5V_CPU': {'avg': 1417, 'cur': 1323}, u'POM_5V_IN': {'avg': 2840, 'cur': 2767}, u'POM_5V_GPU': {'avg': 0, 'cur': 0}}, u'GR3D': {'val': 0}, 'FAN': {'status': 'ON', 'temp': 1, 'cap': 255, 'tpwm': 0, 'step': 100, 'cpwm': 0}, 'CPU': [{'status': 'ON', 'frq': 1428, 'name': 'CPU1', 'val': 5, 'governor': 'schedutil'}, {'status': 'ON', 'frq': 1428, 'name': 'CPU2', 'val': 7, 'governor': 'schedutil'}, {'status': 'ON', 'frq': 1428, 'name': 'CPU3', 'val': 3, 'governor': 'schedutil'}, {'status': 'ON', 'frq': 1428, 'name': 'CPU4', 'val': 100, 'governor': 'schedutil'}]}
{'available': 3.875377655029297, 'total': 13.33111572265625, 'available_no_root': 3.2579383850097656, 'used': 9.455738067626953}
Traceback (most recent call last):
  File "quick_read.py", line 45, in <module>
    print(jetson.fans)
AttributeError: 'jtop' object has no attribute 'fans'
```