### PR TITLE
Fix: add missing http header in order to have correct http response

### DIFF
--- a/examples/jtop_server.py
+++ b/examples/jtop_server.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
                 stats = json.dumps(jetson.stats)
                 # Send by socket
                 if args.http:
-                    conn.send("HTTP/1.1 200 OK\nContent-Type: application/json\n\n" + stats.encode())
+                    conn.send("HTTP/1.1 200 OK\r\nHost: {}:{}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}".format(args.host, args.port, len(stats), stats.encode()))
                 else:
                     conn.send(stats.encode())
                 # Close connection


### PR DESCRIPTION
HTTP headers `Host` and `Content-Length` were missing, browser wasn't able to parse the json response from the server.

It's working better now.