### PR TITLE
Fix for _curses.error: curs_set() returned ERR

### DIFF
--- a/jtop/gui/jtopgui.py
+++ b/jtop/gui/jtopgui.py
@@ -84,8 +84,12 @@ class JTOPGUI:
         # Additionally, we want to make it so that the user does not have to press
         # enter to send keys to our program, so here is how we get keys instantly
         curses.cbreak()
-        # Hide the cursor
-        curses.curs_set(0)
+        # Try to hide the cursor
+        if hasattr(curses, 'curs_set'):
+            try:
+                curses.curs_set(0)
+            except:
+                pass
         # Lastly, keys such as the arrow keys are sent as funny escape sequences to
         # our program. We can make curses give us nicer values (such as curses.KEY_LEFT)
         # so it is easier on us.

--- a/jtop/gui/jtopgui.py
+++ b/jtop/gui/jtopgui.py
@@ -88,7 +88,7 @@ class JTOPGUI:
         if hasattr(curses, 'curs_set'):
             try:
                 curses.curs_set(0)
-            except:
+            except Exception:
                 pass
         # Lastly, keys such as the arrow keys are sent as funny escape sequences to
         # our program. We can make curses give us nicer values (such as curses.KEY_LEFT)


### PR DESCRIPTION
Hi!

jtop fails in my TX2 (Ubuntu 18.04.3 LTS, jetpack 4.2.1, python2.7) 

```
danielef@quantum-box-1:~$ sudo -H pip install jetson-stats
Collecting jetson-stats
  Downloading https://files.pythonhosted.org/packages/e2/23/b1bd08a34a637e7ae2838c7a7847c574056b9804012063344383ca5765ed/jetson-stats-1.7.10.tar.gz (49kB)
    100% |████████████████████████████████| 51kB 543kB/s
Building wheels for collected packages: jetson-stats
  Running setup.py bdist_wheel for jetson-stats ... done
  Stored in directory: /home/danielef/.cache/pip/wheels/2b/43/f4/0ae59f496aa8463719b4eb3474e0fad1ab2cf8f47121528f6b
Successfully built jetson-stats
Installing collected packages: jetson-stats
Successfully installed jetson-stats-1.7.10
danielef@quantum-box-1:~$ jtop
Traceback (most recent call last):
  File "/usr/local/bin/jtop", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/jtop/__main__.py", line 64, in main
    curses.wrapper(JTOPGUI, args.refresh, jetson, [ALL, GPU, CTRL, INFO], init_page=args.page)
  File "/usr/lib/python2.7/curses/wrapper.py", line 43, in wrapper
    return func(stdscr, *args, **kwds)
  File "/usr/local/lib/python2.7/dist-packages/jtop/gui/jtopgui.py", line 78, in __init__
    self.run()
  File "/usr/local/lib/python2.7/dist-packages/jtop/gui/jtopgui.py", line 88, in run
    curses.curs_set(0)
_curses.error: curs_set() returned ERR
```

Seems a curses problem:
```
danielef@quantum-box-1:~$ python
Python 2.7.15+ (default, Oct  7 2019, 17:39:04)
[GCC 7.4.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import curses
>>> curses.version
'2.2'
>>>
```

I add a small piece of code with if-try-except as quickfix.