### PR TITLE
Avoid AttributeError on Python 3.9

### DIFF
--- a/jtop/core/common.py
+++ b/jtop/core/common.py
@@ -176,7 +176,7 @@ def get_local_interfaces():
     max_bytes_out, names_address_out = struct.unpack('iL', mutated_byte_buffer)
     # Convert names to a bytes array - keep in mind we've mutated the names array, so now our bytes out should represent
     # the bytes results of the get iface list ioctl command.
-    namestr = names.tostring()
+    namestr = getattr(names, "tostring", names.tobytes())
     # Each entry is 40 bytes long.  The first 16 bytes are the name string.
     # the 20-24th bytes are IP address octet strings in byte form - one for each byte.
     # Don't know what 17-19 are, or bytes 25:40.


### PR DESCRIPTION
When we seek to 6:INFO we hit AttributeError as the below on Python 3.9 so that I recommend to use tobytes (and tostring for old Python). 

```
Traceback (most recent call last):
  File "/usr/local/bin/jtop", line 33, in <module>
    sys.exit(load_entry_point('jetson-stats==3.1.0', 'console_scripts', 'jtop')())
  File "/usr/local/lib/python3.9/site-packages/jtop/__main__.py", line 148, in main
    curses.wrapper(JTOPGUI, jetson, [ALL, GPU, CPU, MEM, CTRL, INFO], init_page=args.page, loop=args.loop, seconds=LOOP_SECONDS)
  File "/usr/local/lib/python3.9/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "/usr/local/lib/python3.9/site-packages/jtop/gui/jtopgui.py", line 109, in __init__
    self.run(loop, seconds)
  File "/usr/local/lib/python3.9/site-packages/jtop/gui/jtopgui.py", line 138, in run
    self.draw()
  File "/usr/local/lib/python3.9/site-packages/jtop/gui/lib/common.py", line 80, in wrapped
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/jtop/gui/jtopgui.py", line 153, in draw
    page.draw(self.key, self.mouse)
  File "/usr/local/lib/python3.9/site-packages/jtop/gui/pinfo.py", line 96, in draw
    if self.jetson.local_interfaces:
  File "/usr/local/lib/python3.9/site-packages/jtop/jtop.py", line 818, in local_interfaces
    return get_local_interfaces()
  File "/usr/local/lib/python3.9/site-packages/jtop/core/common.py", line 179, in get_local_interfaces
    namestr = names.tostring()
AttributeError: 'array.array' object has no attribute 'tostring'
```