### PR TITLE
Add support for Jetpack 4.6.2

### DIFF
--- a/jtop/jetson_variables
+++ b/jtop/jetson_variables
@@ -30,6 +30,7 @@ jetson_jetpack()
     local JETSON_L4T=$1
     local JETSON_JETPACK=""
     case $JETSON_L4T in
+        "32.7.2") JETSON_JETPACK="4.6.2" ;;
         "32.7.1") JETSON_JETPACK="4.6.1" ;;
         "32.6.1") JETSON_JETPACK="4.6" ;;
         "32.5.1" | "32.5.2") JETSON_JETPACK="4.5.1" ;;


### PR DESCRIPTION
Jetpack 4.6.2 was released recently and this change adds support for it in order to avoid the warning:
```
[WARN] jetson-stats not supported for [L4T 32.7.2]
  Please, try: sudo -H pip install -U jetson-stats
  or open an issue on Github (press CTRL + Click)

```