### PR TITLE
Fix JTOP info exception for python3.9/python3.11

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.4
+        uses: dependabot/fetch-metadata@v1.3.5
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       # Here the PR gets approved.

--- a/jtop/core/common.py
+++ b/jtop/core/common.py
@@ -176,7 +176,7 @@ def get_local_interfaces():
     max_bytes_out, names_address_out = struct.unpack('iL', mutated_byte_buffer)
     # Convert names to a bytes array - keep in mind we've mutated the names array, so now our bytes out should represent
     # the bytes results of the get iface list ioctl command.
-    namestr = names.tostring() if hasattr(names, 'tostring') else names.tobytes()
+    namestr = bytearray(names)
     # Each entry is 40 bytes long.  The first 16 bytes are the name string.
     # the 20-24th bytes are IP address octet strings in byte form - one for each byte.
     # Don't know what 17-19 are, or bytes 25:40.

--- a/jtop/core/common.py
+++ b/jtop/core/common.py
@@ -176,7 +176,7 @@ def get_local_interfaces():
     max_bytes_out, names_address_out = struct.unpack('iL', mutated_byte_buffer)
     # Convert names to a bytes array - keep in mind we've mutated the names array, so now our bytes out should represent
     # the bytes results of the get iface list ioctl command.
-    namestr = names.tostring()
+    namestr = names.tostring() if hasattr(names, 'tostring') else names.tobytes()
     # Each entry is 40 bytes long.  The first 16 bytes are the name string.
     # the 20-24th bytes are IP address octet strings in byte form - one for each byte.
     # Don't know what 17-19 are, or bytes 25:40.


### PR DESCRIPTION
.tostring() is deprecated, .tobytes() can be used instead.

Otherwise in Python3.11 the following error is raised on the info page of JTOP:

AttributeError: 'array.array' object has no attribute 'tostring'
