### PR TITLE
Fix EMC KeyError in jtop.stats property

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -20,7 +20,7 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.4
+        uses: dependabot/fetch-metadata@v1.3.5
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       # Here the PR gets approved.

--- a/jtop/jtop.py
+++ b/jtop/jtop.py
@@ -542,7 +542,7 @@ class jtop(Thread):
         stats['RAM'] = self.ram['use']
         # -- EMC --
         if self.emc:
-            stats['EMC'] = self.emc['use']
+            stats['EMC'] = self.emc['val']
         # -- IRAM --
         if self.iram:
             stats['IRAM'] = self.iram['use']


### PR DESCRIPTION
`jtop.emc` returns either an empty dictionary or a dictionary with keys `"min_freq", "max_freq", "frq", "val", "FreqOverride"`. The `jtop.stats` property was indexing `jtop.emc` with key `"use"`. This PR fixes this.

![image](https://user-images.githubusercontent.com/54745152/210423096-234b8258-f6c3-4c1c-ac5a-1bcab2e6093d.png)