### PR TITLE
Feature/change to smbus2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,6 @@
 
 FROM python:3.12.0a4-slim-bullseye
 
-COPY requirements.txt requirements.txt
-# Install make and gcc to build smbus
-RUN apt-get update && \
-    apt-get install -y make gcc && \
-    pip3 install -r requirements.txt && \
-    rm requirements.txt && \
-    apt-get remove -y make gcc && \
-    rm -rf /var/lib/apt/lists/*
-
 ADD . /jetson_stats
 
 WORKDIR /jetson_stats

--- a/jtop/__init__.py
+++ b/jtop/__init__.py
@@ -26,5 +26,5 @@ __cr__ = "(c) 2023, RB"
 __copyright__ = "(c) 2023, Raffaello Bonghi"
 # Version package
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme
-__version__ = "4.1.3"
+__version__ = "4.1.4"
 # EOF

--- a/jtop/core/jetson_variables.py
+++ b/jtop/core/jetson_variables.py
@@ -24,7 +24,7 @@ import platform
 import logging
 from shutil import copyfile
 try:
-    from smbus import SMBus
+    from smbus2 import SMBus
 except ImportError:
     print("Skip for setup.py")
 # Load distro library from python3 or use platform

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-smbus
+smbus2
 distro


### PR DESCRIPTION
This feature changed from smbus to smbus2.

Using smbus2 is not needed to compile any source #358 