### PR TITLE
Use absolute path for specifying file to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ def pypi_installer(installer, obj, copy):
     installer.run(obj)
     # Run the restart all services before to close the installer
     if not is_virtualenv() and not is_docker() and is_superuser():
-        folder, _ = os.path.split(__file__)  # This folder
+        folder, _ = os.path.split(os.path.realpath(__file__))  # This folder
         # Install variables
         install_variables(folder, copy=copy)
         # Set service permissions


### PR DESCRIPTION
Without this, offline install with `setup.py` (`sudo python3 setup.py install`) will make `install_variables()` try to copy `/scripts/jtop_env.sh` to `/etc/profile.d/jtop_env.sh`. 

`sudo pip3 install -v -e .` does not face this issue.

This issue is reported as https://github.com/rbonghi/jetson_stats/issues/385

