### PR TITLE
Fix model recognise for orin nano

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
       # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.6
+        uses: dependabot/fetch-metadata@v1.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       # Here the PR gets approved.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-FROM python:3.12.0a6-slim-bullseye
+FROM python:3.12.0a7-slim-bullseye
 
 ADD . /jetson_stats
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -18,14 +18,14 @@ You can try running this command
 Design your Dockerfile
 ----------------------
 
-.. code-block:: docker
-
 jetson-stats need few things to be installed on your container.
 
-1. apt-get install -y python3
-2. ``apt-get install -y python3-pip`` or you can install from **source**
+1. ``apt-get install -y python3``
+2. ``apt-get install -y python3-pip`` _or_ you can install from **source**
 
 Below a simple example to install jetson-stats
+
+.. code-block:: docker
 
   FROM python:3-buster
   RUN pip install -U jetson-stats

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -21,7 +21,7 @@ Design your Dockerfile
 jetson-stats need few things to be installed on your container.
 
 1. ``apt-get install -y python3``
-2. ``apt-get install -y python3-pip`` _or_ you can install from **source**
+2. ``apt-get install -y python3-pip`` *or* you can install from **source**
 
 Below a simple example to install jetson-stats
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -45,4 +45,4 @@ You can get the ``JTOP_GID`` by running:
 
   getent group jtop | awk -F: '{print $3}'
 
-Issue reference `#391 https://github.com/rbonghi/jetson_stats/issues/391`_
+Issue reference `391 https://github.com/rbonghi/jetson_stats/issues/391`_

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -20,6 +20,29 @@ Design your Dockerfile
 
 .. code-block:: docker
 
+jetson-stats need few things to be installed on your container.
+
+1. apt-get install -y python3
+2. ``apt-get install -y python3-pip`` or you can install from **source**
+
+Below a simple example to install jetson-stats
+
   FROM python:3-buster
   RUN pip install -U jetson-stats
 
+Tips and tricks
+---------------
+
+If you work with different **multiple users** on your docker container:
+
+.. code-block:: bash
+
+  docker run --group-add $JTOP_GID --rm -it -v /run/jtop.sock:/run/jtop.sock rbonghi/jetson_stats:latest
+
+You can get the ``JTOP_GID`` by running:
+
+.. code-block:: bash
+
+  getent group jtop | awk -F: '{print $3}'
+
+Issue reference `#391 https://github.com/rbonghi/jetson_stats/issues/391`_

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -45,4 +45,4 @@ You can get the ``JTOP_GID`` by running:
 
   getent group jtop | awk -F: '{print $3}'
 
-Issue reference `391 https://github.com/rbonghi/jetson_stats/issues/391`_
+Issue reference `#391 <https://github.com/rbonghi/jetson_stats/issues/391>`_

--- a/jtop/gui/pengine.py
+++ b/jtop/gui/pengine.py
@@ -41,6 +41,15 @@ def pass_orin(engine):
     ]
 
 
+def pass_orin_nano(engine):
+    return [
+        add_engine_in_list('APE', engine, 'APE', 'APE'),
+        add_engine_in_list('NVENC', engine, 'NVENC', 'NVENC') + add_engine_in_list('NVDEC', engine, 'NVDEC', 'NVDEC'),
+        add_engine_in_list('NVJPG', engine, 'NVJPG', 'NVJPG') + add_engine_in_list('NVJPG1', engine, 'NVJPG', 'NVJPG1'),
+        add_engine_in_list('SE', engine, 'SE', 'SE') + add_engine_in_list('VIC', engine, 'VIC', 'VIC'),
+    ]
+
+
 def map_xavier(engine):
     return [
         add_engine_in_list('APE', engine, 'APE', 'APE') + add_engine_in_list('CVNAS', engine, 'CVNAS', 'CVNAS'),
@@ -60,7 +69,7 @@ def map_jetson_nano(engine):
 
 
 MAP_JETSON_MODELS = {
-    'jetson orin': pass_orin,
+    'orin nano': pass_orin_nano,
     'orin nx': pass_orin,
     'agx orin': pass_orin,
     'xavier': map_xavier,

--- a/jtop/gui/pengine.py
+++ b/jtop/gui/pengine.py
@@ -60,6 +60,7 @@ def map_jetson_nano(engine):
 
 
 MAP_JETSON_MODELS = {
+    'jetson orin': pass_orin,
     'orin nx': pass_orin,
     'agx orin': pass_orin,
     'xavier': map_xavier,


### PR DESCRIPTION
This patch fix issue for #400.

The jetson orin nano engines I found through this scipt:
```python
with jtop() as jetson:
    # Read engines list
    engines = jetson.engine
    # Print all engines
    for engine_name in engines:
        engine = engines[engine_name]
        print("{engine_name} = {engine}".format(engine_name=engine_name, engine=engine))
```
With output below:
```shell
APE = {'APE': {'online': False, 'cur': 200000}}
NVDEC = {'NVDEC': {'online': False, 'cur': 524800}}
NVENC = {'NVENC': {'online': False, 'cur': 115200}}
NVJPG = {'NVJPG': {'online': False, 'cur': 115200}, 'NVJPG1': {'online': False, 'cur': 115200}}
SE = {'SE': {'online': True, 'cur': 307200}}
VIC = {'VIC': {'online': False, 'cur': 435200}}
```

So I add `APE` `NVDEC` `NVENC` `NVJPG` `NVJPG1` `SE` and `VIC` into the patch, but I'm not sure if this is right, and I donot really understand the function naming between `pass` & `map`, so feel free to edit ;D