### PR TITLE
Add L4T 35.4.1

### DIFF
--- a/jtop/__init__.py
+++ b/jtop/__init__.py
@@ -31,5 +31,5 @@ __cr__ = "(c) 2023, RB"
 __copyright__ = "(c) 2023, Raffaello Bonghi"
 # Version package
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme
-__version__ = "4.2.2"
+__version__ = "4.3.0"
 # EOF

--- a/jtop/core/jetson_variables.py
+++ b/jtop/core/jetson_variables.py
@@ -42,6 +42,7 @@ if not sys.warnoptions:
 # https://developer.nvidia.com/embedded/jetpack-archive
 NVIDIA_JETPACK = {
     # -------- JP5 --------
+    "35.4.1": "5.1.2",
     "35.3.1": "5.1.1",
     "35.3.0": "5.1.1 PRE",
     "35.2.1": "5.1",


### PR DESCRIPTION
# Add New Jetpack

I resolved <https://github.com/rbonghi/jetson_stats/issues/435>.
And, I checked <https://rnext.it/jetson_stats/contributing.html>.

Checklist:

* [x] Add Jetpack on **`jtop/core/jetson_variables.py`**
* [x] Increase with a minor release jtop variable **`__version__`** in **`jtop/__init__.py`**
* [ ] See if all tests pass
* [x] Merge the release pull request with message "`Jetpack Release <VERSION>`" where `<VERSION>` is the same release in **`jtop/__init__.py`**
* [ ] Get the release Pull request approved by a [CODEOWNER](https://github.com/rbonghi/jetson_stats/blob/master/.github/CODEOWNERS)

## validation

### jetson_release

![test_jetson_release](https://github.com/rbonghi/jetson_stats/assets/2630323/54191b5c-0849-40c7-aa07-ac60df516ab2)

### jtop

![test_jtop](https://github.com/rbonghi/jetson_stats/assets/2630323/f2ff4b79-c502-4092-b6ae-8f579e181d9c)
