### PR TITLE
Fix nprocess set to 0 when no GPU processes active

### DIFF
--- a/jtop/gui/lib/process_table.py
+++ b/jtop/gui/lib/process_table.py
@@ -69,6 +69,7 @@ class ProcessTable(object):
         # Sort table for selected line
         sorted_processes = sorted(processes, key=lambda x: x[self.line_sort], reverse=self.type_reverse)
         # Draw all processes
+        nprocess = 0
         for nprocess, process in enumerate(sorted_processes):
             # Skip unit size process
             counter = 0


### PR DESCRIPTION
When no processes are using the GPU, the value of nprocess is not set and the attempt to return it crashes jtop.
