### PR TITLE
Fix the crash when not all CPUs are online

### DIFF
--- a/jtop/core/cpu.py
+++ b/jtop/core/cpu.py
@@ -112,16 +112,17 @@ def read_system_cpu(path, cpu_status={}):
     if os.path.isfile(path + "/online"):
         with open(path + "/online", 'r') as f:
             cpu_status['online'] = f.read().strip() == '1'
-    # Read governor
-    if os.path.isdir(path + "/cpufreq"):
-        with open(path + "/cpufreq/scaling_governor", 'r') as f:
-            cpu_status['governor'] = f.read().strip()
-        # Store values
-        cpu_status['freq'] = read_freq_cpu(path, 'scaling')
-        cpu_status['info_freq'] = read_freq_cpu(path, 'cpuinfo')
-    # Read idle CPU
-    if os.path.isdir(path + "/cpuidle"):
-        cpu_status['idle_state'] = read_idle(path + "/cpuidle")
+    # Read governor only if CPU is online
+    if cpu_status['online']:
+        if os.path.isdir(path + "/cpufreq"):
+            with open(path + "/cpufreq/scaling_governor", 'r') as f:
+                cpu_status['governor'] = f.read().strip()
+            # Store values
+            cpu_status['freq'] = read_freq_cpu(path, 'scaling')
+            cpu_status['info_freq'] = read_freq_cpu(path, 'cpuinfo')
+        # Read idle CPU
+        if os.path.isdir(path + "/cpuidle"):
+            cpu_status['idle_state'] = read_idle(path + "/cpuidle")
     return cpu_status
 
 


### PR DESCRIPTION
jtop.service fails to start if not all CPUs are online because some sysnodes just return "Resource busy" in that case. 
This change should fix that.

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->