### PR TITLE
Fix crash when starting the service 

### DIFF
--- a/jtop/core/memory.py
+++ b/jtop/core/memory.py
@@ -125,6 +125,8 @@ def read_fstab():
 
 def read_emc(root_path):
     emc = {}
+    # intialize emc['cur'] to avoid a crash when starting this service 
+    emc['cur'] = 1
     if os.path.isdir(root_path + "/debug/bpmp/debug/clk/emc"):
         path = root_path + "/debug/bpmp/debug/clk/emc"
         # Check if access to this file


### PR DESCRIPTION
Initialize `emc['cur']` variable to avoid a crash

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->