### PR TITLE
Conditionally show frequency gauge based on whether CPU core is active

### DIFF
--- a/jtop/gui/pcpu.py
+++ b/jtop/gui/pcpu.py
@@ -119,13 +119,14 @@ class CPU(Page):
         except curses.error:
             pass
         # Print info
-        freq = cpu['freq']
-        freq['online'] = cpu['online']
-        freq['name'] = "Frq"
-        try:
-            freq_gauge(stdscr, pos_y + size_h, pos_x, size_w, cpu['freq'])
-        except curses.error:
-            pass
+        if 'freq' in cpu:
+            freq = cpu['freq']
+            freq['online'] = cpu['online']
+            freq['name'] = "Frq"
+            try:
+                freq_gauge(stdscr, pos_y + size_h, pos_x, size_w, cpu['freq'])
+            except curses.error:
+                pass
 
     def draw(self, key, mouse):
         # Screen size


### PR DESCRIPTION
This pull request fixes a bug where jtop crashes upon switching to the CPU tab on Jetson devices that are running an `nvpmodel` that deactives some of the CPU cores:
```
Traceback (most recent call last):
  File "/usr/local/bin/jtop", line 8, in <module>
    sys.exit(main())
  ...
  File "/usr/local/lib/python3.8/dist-packages/jtop/gui/pcpu.py", line 122, in print_cpu
    freq = cpu['freq']
KeyError: 'freq'
```

**Credit goes to https://github.com/kentdotn for the fix idea in https://github.com/rbonghi/jetson_stats/issues/556#issuecomment-2339718856**