### PR TITLE
Refactor get_cuda() function to check for CUDA version using nvcc command in PATH

### DIFF
--- a/jtop/core/jetson_libraries.py
+++ b/jtop/core/jetson_libraries.py
@@ -50,7 +50,7 @@ def get_cuda():
                     break
         except (OSError, Command.CommandException):
             pass
-    elif subprocess.call(["which", "nvcc"]) == 0:
+    elif subprocess.call(["which", "nvcc"], stdout=subprocess.DEVNULL) == 0:
         cmd = Command(['nvcc', '--version'])
         try:
             lines = cmd()

--- a/jtop/core/jetson_libraries.py
+++ b/jtop/core/jetson_libraries.py
@@ -17,6 +17,7 @@
 
 import os
 import re
+import subprocess
 from .common import cat
 from .command import Command
 # Fix connection refused for python 2.7
@@ -40,6 +41,17 @@ def get_cuda():
             cuda_version = match.group(1)
     elif os.path.isfile("/usr/local/cuda/bin/nvcc"):
         cmd = Command(['/usr/local/cuda/bin/nvcc', '--version'])
+        try:
+            lines = cmd()
+            for line in lines:
+                match = re.search(CUDA_NVCC_RE, line)
+                if match:
+                    cuda_version = match.group(1)
+                    break
+        except (OSError, Command.CommandException):
+            pass
+    elif subprocess.call(["which", "nvcc"]) == 0:
+        cmd = Command(['nvcc', '--version'])
         try:
             lines = cmd()
             for line in lines:


### PR DESCRIPTION
<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

This PR improves the detection of the CUDA version when the CUDA installation is not in the standard `/usr/local/cuda/` path, but the install path has been added to the environment variables.