### PR TITLE
Add OC Event Counter 

### DIFF
--- a/jtop/core/power.py
+++ b/jtop/core/power.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from .common import cat, check_file
+import glob
 import os
 # Logging
 import logging
@@ -104,6 +105,43 @@ def find_all_i2c_power_monitor(i2c_path):
         logger.info("Found I2C power monitor")
     return power_sensor
 
+def find_all_oc_event_counters():
+    """Find all the overcurrent event counters on the system"""
+    event_cnt_files = glob.glob('/sys/class/hwmon/hwmon*/oc*_event_cnt')
+    if (len(event_cnt_files) == 0):
+        logger.warning("No OC event counters found")
+        return {}
+
+    event_counts = {filename: -1 for filename in event_cnt_files}
+
+    update_oc_event_counts(event_counts)
+
+    return event_counts
+
+def update_oc_event_counts(event_counts):
+    """
+    Function to update overcurrent event counts.
+
+    Update the event counts in the event_counts dictionary, and return True if any of the counts have increased
+    """
+    # We can report more granular information about the throttling events if we really want to, but there
+    # is no direct mapping from oc*_event_cnt to which power rail/system is being measured, we
+    # would need to hard code a mapping from board type to oc*_event_cnt->power rail mappings,
+    # this is fragile, and most users will probably only care about throttling or not throttling,
+    # and can use the existing power panel to see currents and current limits if they want to dig deeper.
+    # https://docs.nvidia.com/jetson/archives/r36.4/DeveloperGuide/SD/PlatformPowerAndPerformance/JetsonOrinNanoSeriesJetsonOrinNxSeriesAndJetsonAgxOrinSeries.html#jetson-agx-orin-series
+    throttling = False
+    for filename in event_counts:
+        try:
+            with open(filename, 'r') as f:
+                count = int(f.read())
+                if count > event_counts[filename]:
+                    event_counts[filename] = count
+                    throttling = True
+        except Exception as e:
+            logger.error(f"Error reading OC event counter from {filename}: {e}".format(filename=filename, e=e))
+
+    return throttling
 
 def read_power_status(data):
     values = {}
@@ -237,6 +275,7 @@ class PowerService(object):
     def __init__(self):
         self._power_sensor = {}
         self._power_avg = {}
+        self._oc_event_counts = {}
         # Find all I2C sensors on board
         i2c_path = "/sys/bus/i2c/devices"
         system_monitor = "/sys/class/power_supply"
@@ -248,6 +287,7 @@ class PowerService(object):
         # Load all power sensors
         self._power_sensor = find_all_i2c_power_monitor(i2c_path)
         self._power_sensor.update(find_all_system_monitor(system_monitor))
+        self._oc_event_counts = find_all_oc_event_counters()
         if not self._power_sensor:
             logger.warning("Power sensors not found!")
         # Sort all power sensors
@@ -287,5 +327,14 @@ class PowerService(object):
             rails[name] = values
         # Measure total power
         total, rails = total_power(rails)
-        return {'rail': rails, 'tot': total}
+
+        # If there are OC counters, update those as well
+        oc_events = {}
+        oc_events['is_throttling'] = update_oc_event_counts(self._oc_event_counts)
+        oc_events['count'] = 0
+        # Sum up all the events:
+        for filename, count in self._oc_event_counts.items():
+            oc_events['count'] += count
+
+        return {'rail': rails, 'tot': total, 'oc_events': oc_events}
 # EOF

--- a/jtop/core/power.py
+++ b/jtop/core/power.py
@@ -140,7 +140,7 @@ def update_oc_event_counts(event_counts):
                     throttling = True
         except Exception as e:
             logger.error(f"Error reading OC event counter from {filename}: {e}".format(filename=filename, e=e))
-
+            return throttling
     return throttling
 
 def read_power_status(data):
@@ -330,11 +330,12 @@ class PowerService(object):
 
         # If there are OC counters, update those as well
         oc_events = {}
-        oc_events['is_throttling'] = update_oc_event_counts(self._oc_event_counts)
-        oc_events['count'] = 0
-        # Sum up all the events:
-        for filename, count in self._oc_event_counts.items():
-            oc_events['count'] += count
+        if self._oc_event_counts:
+            oc_events['is_throttling'] = update_oc_event_counts(self._oc_event_counts)
+            oc_events['count'] = 0
+            # Sum up all the events:
+            for filename, count in self._oc_event_counts.items():
+                oc_events['count'] += count
 
         return {'rail': rails, 'tot': total, 'oc_events': oc_events}
 # EOF

--- a/jtop/core/power.py
+++ b/jtop/core/power.py
@@ -105,6 +105,7 @@ def find_all_i2c_power_monitor(i2c_path):
         logger.info("Found I2C power monitor")
     return power_sensor
 
+
 def find_all_oc_event_counters():
     """Find all the overcurrent event counters on the system"""
     event_cnt_files = glob.glob('/sys/class/hwmon/hwmon*/oc*_event_cnt')
@@ -117,6 +118,7 @@ def find_all_oc_event_counters():
     update_oc_event_counts(event_counts)
 
     return event_counts
+
 
 def update_oc_event_counts(event_counts):
     """
@@ -139,9 +141,10 @@ def update_oc_event_counts(event_counts):
                     event_counts[filename] = count
                     throttling = True
         except Exception as e:
-            logger.error(f"Error reading OC event counter from {filename}: {e}".format(filename=filename, e=e))
+            logger.error("Error reading OC event counter from {filename}: {e}".format(filename=filename, e=e))
             return throttling
     return throttling
+
 
 def read_power_status(data):
     values = {}

--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -118,7 +118,7 @@ def compact_power(stdscr, pos_y, pos_x, width, height, jetson):
     oc_event_cnt = jetson.power['oc_events']['count']
     is_throttling = jetson.power['oc_events']['is_throttling']
     # Plot OC_EVENT_CNT with color based on throttling status
-    color =  NColors.red() if is_throttling else (NColors.yellow() if oc_event_cnt > 0 else NColors.green())
+    color = NColors.red() if is_throttling else (NColors.yellow() if oc_event_cnt > 0 else NColors.green())
     stdscr.addstr(pos_y + len_power + 3, center_x - column_power - 5, "OC EVENT COUNT: ", curses.A_BOLD)
     stdscr.addstr(pos_y + len_power + 3, center_x + 2, str(oc_event_cnt), curses.A_BOLD | color)
     return len(power) + 3
@@ -398,11 +398,9 @@ class CTRL(Page):
         oc_event_cnt = self.jetson.power['oc_events']['count']
         is_throttling = self.jetson.power['oc_events']['is_throttling']
         # Plot OC_EVENT_CNT with color based on throttling status
-        color =  NColors.red() if is_throttling else (NColors.yellow() if oc_event_cnt > 0 else NColors.green())
+        color = NColors.red() if is_throttling else (NColors.yellow() if oc_event_cnt > 0 else NColors.green())
         self.stdscr.addstr(pos_y_table + len_power + 2, pos_x, "OC EVENT COUNT: ", curses.A_BOLD)
-        self.stdscr.addstr(pos_y_table + len_power+ 2, pos_x + 16, str(oc_event_cnt), curses.A_BOLD | color)
-
-
+        self.stdscr.addstr(pos_y_table + len_power + 2, pos_x + 16, str(oc_event_cnt), curses.A_BOLD | color)
 
     def draw(self, key, mouse):
         # Screen size

--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -106,17 +106,21 @@ def compact_power(stdscr, pos_y, pos_x, width, height, jetson):
         unit_avg = unit_to_string(total['avg'], 'm', 'W')
         stdscr.addstr(pos_y + len_power + 1, center_x + column_power - 3, unit_avg, curses.A_BOLD)
 
-    # If there is room, plot OC_EVENT_CNT
+    # If there is no more space, return
     if len_power + 3 >= height:
         return len(power) + 1
+
+    # if there are no OC events, return
+    if not jetson.power['oc_events']:
+        return len(power) + 1
+
+    # Plot OC_EVENT_CNT
     oc_event_cnt = jetson.power['oc_events']['count']
     is_throttling = jetson.power['oc_events']['is_throttling']
-    # blank line
-    stdscr.addstr(pos_y + len_power + 2, center_x - column_power - 5, "", curses.A_NORMAL)
     # Plot OC_EVENT_CNT with color based on throttling status
-    color =  NColors.ired() if is_throttling else (NColors.iyellow() if oc_event_cnt > 0 else NColors.igreen())
-    stdscr.addstr(pos_y + len_power + 3, center_x - column_power - 5, "OC_EVENT_CNT ", curses.A_BOLD | color)
-    stdscr.addstr(pos_y + len_power + 3, center_x - 1, str(oc_event_cnt), curses.A_BOLD | color)
+    color =  NColors.red() if is_throttling else (NColors.yellow() if oc_event_cnt > 0 else NColors.green())
+    stdscr.addstr(pos_y + len_power + 3, center_x - column_power - 5, "OC EVENT COUNT: ", curses.A_BOLD)
+    stdscr.addstr(pos_y + len_power + 3, center_x + 2, str(oc_event_cnt), curses.A_BOLD | color)
     return len(power) + 3
 
 
@@ -385,6 +389,20 @@ class CTRL(Page):
                 self.stdscr.addstr(pos_y_table + len_power, pos_x + 47, unit_curr_crit, curses.A_BOLD)
         except curses.error:
             pass
+
+        # if there are no OC events, return
+        if not self.jetson.power['oc_events']:
+            return
+
+        # Plot OC_EVENT_CNT
+        oc_event_cnt = self.jetson.power['oc_events']['count']
+        is_throttling = self.jetson.power['oc_events']['is_throttling']
+        # Plot OC_EVENT_CNT with color based on throttling status
+        color =  NColors.red() if is_throttling else (NColors.yellow() if oc_event_cnt > 0 else NColors.green())
+        self.stdscr.addstr(pos_y_table + len_power + 2, pos_x, "OC EVENT COUNT: ", curses.A_BOLD)
+        self.stdscr.addstr(pos_y_table + len_power+ 2, pos_x + 16, str(oc_event_cnt), curses.A_BOLD | color)
+
+
 
     def draw(self, key, mouse):
         # Screen size

--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -105,7 +105,19 @@ def compact_power(stdscr, pos_y, pos_x, width, height, jetson):
     if width > LIMIT:
         unit_avg = unit_to_string(total['avg'], 'm', 'W')
         stdscr.addstr(pos_y + len_power + 1, center_x + column_power - 3, unit_avg, curses.A_BOLD)
-    return len(power) + 1
+
+    # If there is room, plot OC_EVENT_CNT
+    if len_power + 3 >= height:
+        return len(power) + 1
+    oc_event_cnt = jetson.power['oc_events']['count']
+    is_throttling = jetson.power['oc_events']['is_throttling']
+    # blank line
+    stdscr.addstr(pos_y + len_power + 2, center_x - column_power - 5, "", curses.A_NORMAL)
+    # Plot OC_EVENT_CNT with color based on throttling status
+    color =  NColors.ired() if is_throttling else (NColors.iyellow() if oc_event_cnt > 0 else NColors.igreen())
+    stdscr.addstr(pos_y + len_power + 3, center_x - column_power - 5, "OC_EVENT_CNT ", curses.A_BOLD | color)
+    stdscr.addstr(pos_y + len_power + 3, center_x - 1, str(oc_event_cnt), curses.A_BOLD | color)
+    return len(power) + 3
 
 
 class CTRL(Page):


### PR DESCRIPTION
Adds a display for overcurrent events, OC events cause severe throttling of CPU/GPU clocks, and often users don't realize this at all. 

TODO - still needs additional testing under load and outside of AGX Orin.