### PR TITLE
Add Jetson AGX Thor (t26x / tegra264) support: board detection + UI variables

### DIFF
--- a/jtop/core/jetson_variables.py
+++ b/jtop/core/jetson_variables.py
@@ -42,6 +42,8 @@ if not sys.warnoptions:
 # https://developer.nvidia.com/embedded/jetpack-archive
 NVIDIA_JETPACK = {
     # -------- JP6 --------
+    "38.2.0": "7.0",
+    "36.4.4": "6.2.1",
     "36.4.3": "6.2",
     "36.4.2": "6.1 (rev1)",
     "36.4.0": "6.1",
@@ -116,6 +118,7 @@ NVIDIA_JETPACK = {
 
 
 CUDA_TABLE = {
+    'tegra264': '13.0', # JETSON THOR - tegra264
     'tegra234': '8.7',  # JETSON ORIN - tegra234
     'tegra23x': '8.7',  # JETSON ORIN - tegra234
     'tegra194': '7.2',  # JETSON XAVIER
@@ -128,6 +131,7 @@ CUDA_TABLE = {
 # https://docs.nvidia.com/jetson/archives/l4t-archived/l4t-3231/index.html
 # https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/IN/QuickStart.html
 MODULE_NAME_TABLE = {
+    'p3834-0008': 'NVIDIA Jetson AGX Thor  (Developer kit)',
     'p3767-0005': 'NVIDIA Jetson Orin Nano (Developer kit)',
     'p3767-0004': 'NVIDIA Jetson Orin Nano (4GB ram)',
     'p3767-0003': 'NVIDIA Jetson Orin Nano (8GB ram)',

--- a/jtop/github.py
+++ b/jtop/github.py
@@ -134,6 +134,7 @@ def hyperlink(message, url, text):
     # 5. https://stackoverflow.com/questions/44078888/clickable-html-links-in-python-3-6-shell
     # Print starting message
     print("[{status}] {message}".format(status=bcolors.warning(), message=message))
+    print("  For now, ignore the next 3 lines or it will rollback jtop to not functioning on Thor".format(bold=bcolors.BOLD, reset=bcolors.ENDC))
     print("  Please, try: {bold}sudo pip3 install -U jetson-stats{reset} or".format(bold=bcolors.BOLD, reset=bcolors.ENDC))
     # Generate hyperlink for shell
     # Check type of shell

--- a/services/jtop.service
+++ b/services/jtop.service
@@ -20,6 +20,7 @@ After=multi-user.target
 [Service]
 # Type=exec
 Environment="JTOP_SERVICE=True"
+ExecStart=/opt/jtop/venv/bin/jtop --force
 ExecStart=/usr/local/bin/jtop --force
 Restart=on-failure
 RestartSec=10s


### PR DESCRIPTION
Summary
This PR adds first-class support for Jetson AGX Thor (t26x / tegra264) so jtop detects the board/JetPack correctly and the UI behaves as expected on Thor.

Why
On Thor, jtop mis-detects platform details and some UI elements don’t render correctly. This updates detection/mappings so jtop works out-of-the-box on JetPack 7.x (L4T 38.x) for Thor.

Changes

jetson_stats/jtop/core/jetson_variables.py

Add Thor/t26x identifiers and 2 more cpus

Populate board name(s) (e.g., jetson-agx-thor-devkit) 