### PR TITLE
Added version for jetpack detection

### DIFF
--- a/jtop/core/jetson_variables.py
+++ b/jtop/core/jetson_variables.py
@@ -42,6 +42,7 @@ if not sys.warnoptions:
 # https://developer.nvidia.com/embedded/jetpack-archive
 NVIDIA_JETPACK = {
     # -------- JP6 --------
+    "36.4.4": "6.2.1",
     "36.4.3": "6.2",
     "36.4.2": "6.1 (rev1)",
     "36.4.0": "6.1",


### PR DESCRIPTION
Added version for nvidia-jetpack 6.2.1 to detection for nvidia-l4t-core 36.4.4-20250616085344.

## Summary by Sourcery

New Features:
- Map L4T core version 36.4.4 to Jetpack version 6.2.1 in the jetson variables dictionary