### PR TITLE
jtop/github.py: delete print statement that was added for Thor and is…

### DIFF
--- a/jtop/github.py
+++ b/jtop/github.py
@@ -134,7 +134,6 @@ def hyperlink(message, url, text):
     # 5. https://stackoverflow.com/questions/44078888/clickable-html-links-in-python-3-6-shell
     # Print starting message
     print("[{status}] {message}".format(status=bcolors.warning(), message=message))
-    print("  For now, ignore the next 3 lines or it will rollback jtop to not functioning on Thor")
     print("  Please, try: {bold}sudo pip3 install -U jetson-stats{reset} or".format(bold=bcolors.BOLD, reset=bcolors.ENDC))
     # Generate hyperlink for shell
     # Check type of shell


### PR DESCRIPTION
… not needed with SUDO installed jtop'

I added that print statement so that people that installed jtop with shell scripts I'd posted to 
[https://forums.developer.nvidia.com/t/a-method-to-install-jtop-on-thor-without-break-system-packages/344099](url)  around September 4, 2025,  would not receive print statement upon every exit of jtop that instructed them to use     sudo pip3 install -U jetson_stats.  