### PR TITLE
Fix warning message when I close jtop

### DIFF
--- a/jtop/gui/pengine.py
+++ b/jtop/gui/pengine.py
@@ -140,6 +140,8 @@ def compact_engines(stdscr, pos_y, pos_x, width, height, jetson):
     # Plot all engines
     size_table = 26
     for gidx, row in enumerate(map_eng):
+        if len(row) == 0:  # Skip empty rows to avoid division by zero
+            continue
         size_eng = size_table // len(row) - 1
         for idx, (name, value) in enumerate(row):
             if name is not None:


### PR DESCRIPTION
## Summary by Sourcery

Add Jetson Thor engine mapping and guard against empty rows in compact_engines to eliminate division-by-zero warnings

New Features:
- Add support for Jetson Thor GPU by introducing pass_thor engine mapping and registering it in MAP_JETSON_MODELS

Bug Fixes:
- Prevent division by zero in compact_engines by skipping empty engine rows