### PR TITLE
perf(core): disable per-second NVML device count log in gpu.py

### DIFF
--- a/jtop/core/gpu.py
+++ b/jtop/core/gpu.py
@@ -281,7 +281,8 @@ def nvml_read_gpu_status() -> Dict[str, Dict[str, Any]]:
         pynvml.nvmlInit()
 
         device_count = pynvml.nvmlDeviceGetCount()
-        logger.info(f"NVML device count: {device_count}")
+        # comment out next line which writes every second to journalctl. Enable locally if needed.
+        #logger.info(f"NVML device count: {device_count}")
 
         for idx in range(device_count):
             handle = pynvml.nvmlDeviceGetHandleByIndex(idx)


### PR DESCRIPTION
Commented out the line that logs NVML device count every second to reduce journalctl log noise and CPU I/O overhead. 

        # logger.info(f"NVML device count: {device_count}"

## Summary by Sourcery

Enhancements:
- Comment out per-second NVML device count logger call in gpu.py to improve performance and reduce log noise