### PR TITLE
fix thor gpu page vram display error

### DIFF
--- a/jtop/core/jetson_variables.py
+++ b/jtop/core/jetson_variables.py
@@ -144,7 +144,7 @@ CUDA_TABLE = {
 # https://docs.nvidia.com/jetson/archives/l4t-archived/l4t-3231/index.html
 # https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/IN/QuickStart.html
 MODULE_NAME_TABLE = {
-    'p3834-0008': 'NVIDIA Jetson AGX Thor  (Developer kit)',
+    'p3834-0008': 'NVIDIA Jetson AGX Thor (Developer kit)',
     'p3767-0005': 'NVIDIA Jetson Orin Nano (Developer kit)',
     'p3767-0004': 'NVIDIA Jetson Orin Nano (4GB ram)',
     'p3767-0003': 'NVIDIA Jetson Orin Nano (8GB ram)',

--- a/jtop/gui/pgpu_thor.py
+++ b/jtop/gui/pgpu_thor.py
@@ -106,13 +106,13 @@ def compact_gpu(stdscr, pos_y, pos_x, width, jetson, mouse=None):
     y = pos_y + line_counter
     label1_x = pos_x + 1
     label1 = "3D scaling: "
-    field1 = "{" + val3d + "}"
+    field1 = "[" + val3d + "]"
     field1_x = label1_x + len(label1)
     field1_x_end = field1_x + len(field1) - 1
 
     label2_x = pos_x + max(width // 2, field1_x_end + 3)
     label2 = "Railgate: "
-    field2 = "{" + valrg + "}"
+    field2 = "[" + valrg + "]"
     field2_x = label2_x + len(label2)
     field2_x_end = field2_x + len(field2) - 1
 
@@ -304,7 +304,7 @@ class GPU(Page):
 
                 chart_ram.draw(
                     self.stdscr,
-                    [1 + width // 2, width - 2],
+                    [width // 2, width - 3],
                     size_y,
                     label=label_mem,
                 )


### PR DESCRIPTION
vram of AGX Thor exceeds 100, so it needs to move forward one space when drawing graphics to avoid errors in displaying on the next line

## Summary by Sourcery

Adjust Thor GPU VRAM display layout and labels to correctly render high VRAM values and tidy device naming.

Enhancements:
- Change 3D scaling and Railgate value delimiters from braces to brackets in the compact GPU view for clearer display.
- Update VRAM chart horizontal positioning and width in the Thor GPU view to prevent wrapping issues with large VRAM values.
- Clean up the AGX Thor module name string by removing an extra space in the developer kit label.