### PR TITLE
install: ensure jtop group exists for no-sudo setup

### DIFF
--- a/scripts/install_jtop_torun_without_sudo.sh
+++ b/scripts/install_jtop_torun_without_sudo.sh
@@ -39,6 +39,9 @@ fi
 
 export PATH="$HOME/.local/bin:$PATH"
 
+# To be safe let's make sure group jtop exists.
+sudo groupadd -f jtop
+
 echo "Creating Python virtual environment in $VENV_DIR..."
 uv venv "$VENV_DIR" -p python3.12 --seed
 


### PR DESCRIPTION
On a freshly re-flashed Jetson Thor, jtop.service did not start until I ran: sudo groupadd -f jtop.

Add 'sudo groupadd -f jtop' to scripts/install_jtop_torun_without_sudo.sh to ensure the group exists and improve first-run reliability.

## Summary by Sourcery

Enhancements:
- Add a step in the no-sudo jtop installation script to create the jtop group if it does not already exist.