### PR TITLE
Call close() in __exit__() when using jtop as a context manager

### DIFF
--- a/jtop/jtop.py
+++ b/jtop/jtop.py
@@ -1280,7 +1280,14 @@ sudo jtop --install-service""".format(
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """ Exit function for 'with' statement """
-        if exc_tb is not None:
-            return False
-        return True
+        try:
+            try:
+                self.close()
+            except Exception:
+                pass
+
+        finally:
+            if exc_tb is not None:
+                return False
+            return True
 # EOF


### PR DESCRIPTION
While reading the implementation of the context manager, I noticed that __exit__() does not explicitly call close().

This made me curious about the intended lifecycle management when jtop is used with a `with` statement. The documentation mentions that close() is not required when using:

    with jtop() as jetson:
        ...

In my case, I was repeatedly creating jtop instances inside a loop using `with jtop() as jetson`. I realize now that this usage pattern is probably not ideal and that reusing a single jtop instance would be more appropriate.

However, during testing I observed that the number of open file descriptors in the process kept increasing over time. Initially I assumed that the `with` statement would automatically release all resources, but it seems that __exit__() currently does not explicitly trigger close().

To ensure cleanup when leaving the context manager, this change simply calls close() inside __exit__().

I would also appreciate any clarification on whether the current behavior is intentional, or if calling close() here is the expected way to manage resources when using the context manager.

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Bug Fixes:
- Call close() when exiting the jtop context manager to prevent resource leaks such as accumulating open file descriptors.