### PR TITLE
Handle old python3/pip3 versions and PATH variations in pip uninstall…

### DIFF
--- a/scripts/upgrade-jtop.sh
+++ b/scripts/upgrade-jtop.sh
@@ -65,7 +65,10 @@ remove_legacy_jtop() {
             /usr/local/bin/python3 /usr/local/bin/python3.[0-9]*; do
     if [[ -x "$py" ]]; then
       echo "Trying: sudo $py -m pip uninstall -y jetson-stats jetson_stats"
-      sudo "$py" -m pip uninstall -y jetson-stats jetson_stats || true
+      if ! sudo "$py" -m pip uninstall -y jetson-stats jetson_stats; then
+        echo "Retrying with --break-system-packages for externally managed Python..."
+        sudo "$py" -m pip uninstall -y --break-system-packages jetson-stats jetson_stats || true
+      fi
     fi
   done
 
@@ -91,6 +94,25 @@ remove_legacy_jtop() {
     sudo rm -rf "${leftover_dirs[@]}"
   else
     echo "All legacy jtop directories removed."
+  fi
+
+  # Remove any old jetson_stats*dist-info/ directories pip may have left behind.
+  local dist_info_dirs=()
+  while IFS= read -r path; do
+    dist_info_dirs+=("$path")
+  done < <(
+    sudo find /usr/lib /usr/local/lib \
+      -type d \
+      -name 'jetson_stats-*.dist-info' \
+      -path '*/python3*/*-packages/*' \
+      -prune \
+      -print
+  )
+
+  if (( ${#dist_info_dirs[@]} > 0 )); then
+    echo "Removing leftover dist-info directories:"
+    printf '  %s\n' "${dist_info_dirs[@]}"
+    sudo rm -rf "${dist_info_dirs[@]}"
   fi
 }
 


### PR DESCRIPTION
… jetson-stats

Modified the jtop upgrade script to handle older Python3 / pip3 versions and variable $PATH

  - If earlier version installed jetson-stats / jtop module exists
  - Attempts a standard `pip uninstall jetson-stats` first
  - Falls back to `sudo pip uninstall --break-system-packages jetson-stats` if the initial attempt fails
  - Remaining directly related `jetson_stats-*.dist-info` directories are then removed.

Then the upgrade script continues to install current jetson-stats / jtop version.

This ensures a clean, reliable upgrade path with no leftover files or extraneous error messages.

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Improve the jtop upgrade script’s handling of legacy jetson-stats installations for varied Python/pip environments.

Bug Fixes:
- Ensure legacy jetson-stats installations are reliably uninstalled even on systems with externally managed Python or older pip behavior.
- Clean up leftover jetson_stats dist-info metadata directories after uninstall to avoid stale package artifacts.