### PR TITLE
Fix Thor Engines 5ENG to display values

### DIFF
--- a/jtop/service.py
+++ b/jtop/service.py
@@ -755,6 +755,17 @@ class JtopServer(Process):
                         jp_group[name.upper()] = status
                     data["engines"]["JP"] = jp_group
 
+            # Flatten engine cur frequencies into data["flat"] so the Thor GUI
+            # renderer (draw_thor_engines_from_stats / compact_engines) can find
+            # them via flat.get("NVDEC0") etc.
+            jp_group = data["engines"].get("JP")
+            if isinstance(jp_group, dict):
+                for eng_name, eng_data in jp_group.items():
+                    if isinstance(eng_data, dict):
+                        cur = eng_data.get("cur")
+                        if cur is not None:
+                            flat[eng_name] = cur
+
             # Canary marker (namespaced; never top-level)
             flat["JP_OVERLAY"] = 1
 


### PR DESCRIPTION
On Thor, Engines consistently shown as IDLE on the 5Engine and Main pages. This occurs because `service.py` does not write the current engine values into `data["flat"]`, which is where the Thor renderer reads them from.

Added a small update to `apply_jetsonpower_overlay()` in `service.py` to ensure `jp_engines` are flattened into `data["flat"]`.

- Added `scripts/exercise_thor_engines.py` exercise the engines to confirm telemetry pipelines.


**Working as intended:**
- [x] NVDEC0 / NVDEC1
- [x] NVENC0 / NVENC1
- [x] NVJPG0 / NVJPG1
- [x] SE
- [x] VIC

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Bug Fixes:
- Populate flat engine frequency values so Thor 5-engine and main views no longer show engines as always IDLE.