### PR TITLE
Feature add on Thor 2GPU to display Compute/Graphic process type

### DIFF
--- a/jtop/core/process_types.py
+++ b/jtop/core/process_types.py
@@ -1,0 +1,20 @@
+# -*- coding: UTF-8 -*-
+# This file is part of the jetson_stats package (https://github.com/rbonghi/jetson_stats or http://rnext.it).
+# Copyright (c) 2019-2026 Raffaello Bonghi.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+PROCESS_TYPE_COMPUTE = "Compute"
+PROCESS_TYPE_GRAPHIC = "Graphic"
+# EOF

--- a/jtop/core/processes.py
+++ b/jtop/core/processes.py
@@ -92,7 +92,7 @@ class ProcessService(object):
         # Initialization memory
         logger.info("Process service started")
 
-    def get_process_info(self, pid, gpu_mem_usage, process_name, uptime):
+    def get_process_info(self, pid, gpu_mem_usage, process_name, uptime, process_type="Graphic"):
         # Check if exist folder
         if not os.path.isdir(os.path.join('/proc', pid)):
             return []
@@ -129,7 +129,7 @@ class ProcessService(object):
             int(pid),               # pid process
             self.usernames[uid],    # username
             "I",                    # GPU name
-            "Graphic",              # type process
+            process_type,           # type process
             int(stat[17]),          # Priority
             stat[2],                # state
             cpu_percent,            # CPU percent
@@ -147,7 +147,7 @@ class ProcessService(object):
         if self._isThor and self._nvml_process_table is not None:
             # nvidia.ko stack (Thor): nvmap absent, NVML gives compute+graphics
             total, raw = self._nvml_process_table()
-            table = [self.get_process_info(prc[0], prc[3], prc[2], uptime) for prc in raw if prc]
+            table = [self.get_process_info(prc[0], prc[3], prc[2], uptime, prc[4]) for prc in raw if prc]
         elif self._isJetson:
             # nvgpu stack (Orin): nvmap debugfs is the authoritative source
             total, raw = read_process_table(self._root_path + "/debug/nvmap/iovmm/maps")

--- a/jtop/core/processes.py
+++ b/jtop/core/processes.py
@@ -20,6 +20,7 @@ import os
 import pwd
 from .common import cat
 from .hw_detect import is_thor
+from .thor_gpu import PROCESS_TYPE_GRAPHIC
 # Logging
 import logging
 # Create logger
@@ -92,7 +93,7 @@ class ProcessService(object):
         # Initialization memory
         logger.info("Process service started")
 
-    def get_process_info(self, pid, gpu_mem_usage, process_name, uptime, process_type="Graphic"):
+    def get_process_info(self, pid, gpu_mem_usage, process_name, uptime, process_type=PROCESS_TYPE_GRAPHIC):
         # Check if exist folder
         if not os.path.isdir(os.path.join('/proc', pid)):
             return []

--- a/jtop/core/processes.py
+++ b/jtop/core/processes.py
@@ -20,7 +20,7 @@ import os
 import pwd
 from .common import cat
 from .hw_detect import is_thor
-from .thor_gpu import PROCESS_TYPE_GRAPHIC
+from .process_types import PROCESS_TYPE_GRAPHIC
 # Logging
 import logging
 # Create logger

--- a/jtop/core/thor_gpu.py
+++ b/jtop/core/thor_gpu.py
@@ -48,8 +48,7 @@ from .thor_power import (
 
 logger = logging.getLogger(__name__)
 
-PROCESS_TYPE_COMPUTE = "Compute"
-PROCESS_TYPE_GRAPHIC = "Graphic"
+from .process_types import PROCESS_TYPE_COMPUTE, PROCESS_TYPE_GRAPHIC
 
 # Thor detection: present if the devfreq GPC domain exists
 THOR_GPC = "/sys/class/devfreq/gpu-gpc-0"

--- a/jtop/core/thor_gpu.py
+++ b/jtop/core/thor_gpu.py
@@ -86,9 +86,9 @@ def nvml_process_table() -> Tuple[int, List]:
     by PID with max() so a process that appears in both lists (common on Thor)
     is counted once at its peak allocation.
 
-    Row format: [pid_str, 'user', process_name, gpu_mem_kb]
-    This matches read_process_table() so ProcessService can consume it
-    without changes.
+    Row format: [pid_str, 'user', process_name, gpu_mem_kb, type_str]
+    type_str is "Compute" or "Graphic"; a PID in both lists is classified
+    as "Compute" (compute getter is queried first).
 
     pynvml is a declared jetson-stats dependency and is available in the jtop
     venv.  NVML does not create a CUDA context — no host1x/DRM side-effects.
@@ -103,15 +103,16 @@ def nvml_process_table() -> Tuple[int, List]:
         return 0, []
     pid_mem: Dict[int, int] = {}
     pid_name: Dict[int, str] = {}
+    pid_type: Dict[int, str] = {}
     for idx in range(count):
         try:
             h = _pynvml.nvmlDeviceGetHandleByIndex(idx)
         except _pynvml.NVMLError as e:
             logger.debug("nvmlDeviceGetHandleByIndex(%d) failed: %s", idx, e)
             continue
-        for getter in (
-            _pynvml.nvmlDeviceGetComputeRunningProcesses,
-            _pynvml.nvmlDeviceGetGraphicsRunningProcesses,
+        for getter, type_str in (
+            (_pynvml.nvmlDeviceGetComputeRunningProcesses, "Compute"),
+            (_pynvml.nvmlDeviceGetGraphicsRunningProcesses, "Graphic"),
         ):
             try:
                 procs = getter(h)
@@ -121,13 +122,16 @@ def nvml_process_table() -> Tuple[int, List]:
                 mem_kb = (p.usedGpuMemory or 0) // 1024
                 # max() — same PID in both lists means same allocation
                 pid_mem[p.pid] = max(pid_mem.get(p.pid, 0), mem_kb)
+                # Compute wins: first-seen type is kept (Compute iterated first)
+                if p.pid not in pid_type:
+                    pid_type[p.pid] = type_str
                 if p.pid not in pid_name:
                     try:
                         pid_name[p.pid] = _pynvml.nvmlSystemGetProcessName(p.pid).split('/')[-1]
                     except _pynvml.NVMLError:
                         pid_name[p.pid] = str(p.pid)
     total_kb = sum(pid_mem.values())
-    rows = [[str(pid), 'user', pid_name[pid], pid_mem[pid]] for pid in pid_mem]
+    rows = [[str(pid), 'user', pid_name[pid], pid_mem[pid], pid_type[pid]] for pid in pid_mem]
     return total_kb, rows
 
 

--- a/jtop/core/thor_gpu.py
+++ b/jtop/core/thor_gpu.py
@@ -17,6 +17,7 @@
 
 # Thor GPU backend for jtop — uses sysfs + thor_power helpers
 
+from .process_types import PROCESS_TYPE_COMPUTE, PROCESS_TYPE_GRAPHIC
 import logging
 import os
 import time
@@ -48,7 +49,6 @@ from .thor_power import (
 
 logger = logging.getLogger(__name__)
 
-from .process_types import PROCESS_TYPE_COMPUTE, PROCESS_TYPE_GRAPHIC
 
 # Thor detection: present if the devfreq GPC domain exists
 THOR_GPC = "/sys/class/devfreq/gpu-gpc-0"

--- a/jtop/core/thor_gpu.py
+++ b/jtop/core/thor_gpu.py
@@ -48,6 +48,9 @@ from .thor_power import (
 
 logger = logging.getLogger(__name__)
 
+PROCESS_TYPE_COMPUTE = "Compute"
+PROCESS_TYPE_GRAPHIC = "Graphic"
+
 # Thor detection: present if the devfreq GPC domain exists
 THOR_GPC = "/sys/class/devfreq/gpu-gpc-0"
 
@@ -111,8 +114,8 @@ def nvml_process_table() -> Tuple[int, List]:
             logger.debug("nvmlDeviceGetHandleByIndex(%d) failed: %s", idx, e)
             continue
         for getter, type_str in (
-            (_pynvml.nvmlDeviceGetComputeRunningProcesses, "Compute"),
-            (_pynvml.nvmlDeviceGetGraphicsRunningProcesses, "Graphic"),
+            (_pynvml.nvmlDeviceGetComputeRunningProcesses, PROCESS_TYPE_COMPUTE),
+            (_pynvml.nvmlDeviceGetGraphicsRunningProcesses, PROCESS_TYPE_GRAPHIC),
         ):
             try:
                 procs = getter(h)

--- a/jtop/gui/lib/process_table.py
+++ b/jtop/gui/lib/process_table.py
@@ -25,7 +25,7 @@ header = [
     ("PID", {'clm': 7, 'fn': lambda x: str(x)}),
     ("USER", {'clm': 9, 'fn': lambda x: x}),
     ("GPU", {'clm': 5, 'fn': lambda x: x}),
-    ("TYPE", {'clm': 6, 'fn': lambda x: x[0]}),
+    ("TYPE", {'clm': 9, 'fn': lambda x: x}),
     ("PRI", {'clm': 5, 'fn': lambda x: str(x)}),
     ("S", {'clm': 4, 'fn': lambda x: x}),
     ("CPU%", {'clm': 7, 'fn': lambda x: "{:.1f}".format(x)}),


### PR DESCRIPTION
display Compute/Graphic process type in TYPE column

This replaces current 2GPU Type column that displays simply `G`.

nvml_process_table() now tracks which NVML getter (`Compute` vs `Graphic`) found each PID. The type is passed through ProcessService and displayed as the full word in the process table. Non-Thor platforms are unaffected (default changes from `G` to `Graphic`).

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Display NVML-derived GPU process type information in the process table and propagate it through the process service and GUI.

New Features:
- Show separate Compute vs Graphic GPU process types for Thor 2GPU NVML-based process reporting.

Enhancements:
- Extend NVML process table rows and process service to carry process type metadata, defaulting non-Thor platforms to Graphic.
- Update GUI process table TYPE column to render the full process type label instead of a single-letter code.