### PR TITLE
Fix static GPU controls on JetPack 7.2 for Orin

### DIFF
--- a/jtop/core/gpu.py
+++ b/jtop/core/gpu.py
@@ -552,9 +552,12 @@ class GPUService(object):
                 return False
 
         # Fall back to NVML on JetPack 7.0+ (Thor, or boards without a sysfs iGPU)
-        if check_jetpack_version() and NVML_AVAILABLE and self._try_nvml_init():
-            return True
-        logger.info("NVML unavailable, falling back to traditional method")
+        if check_jetpack_version() and NVML_AVAILABLE:
+            if self._try_nvml_init():
+                return True
+            logger.info("NVML initialization failed, falling back to traditional method")
+        else:
+            logger.info("NVML not available, using traditional method")
 
         # Last resort: traditional sysfs (covers any board not handled above)
         if not self._gpu_list:
@@ -605,16 +608,17 @@ class GPUService(object):
         if '3d_scaling_governor' in self._gpu_list[name]:
             gov_path = self._gpu_list[name]['3d_scaling_governor']
             target = "nvhost_podgov" if value else "performance"
+            if not os.access(gov_path, os.W_OK):
+                logger.error(f"GPU \"{name}\" governor {gov_path} is not writable")
+                return False
             try:
-                if os.access(gov_path, os.W_OK):
-                    with open(gov_path, 'w') as f:
-                        f.write(target)
-                    logger.info(f"GPU \"{name}\" set 3D scaling to {value} (governor={target})")
-                else:
-                    logger.error(f"GPU \"{name}\" governor {gov_path} is not writable")
+                with open(gov_path, 'w') as f:
+                    f.write(target)
             except OSError as e:
                 logger.error(f"I cannot set 3D scaling governor {e}")
-            return
+                return False
+            logger.info(f"GPU \"{name}\" set 3D scaling to {value} (governor={target})")
+            return True
         if '3d_scaling' not in self._gpu_list[name]:
             logger.error(f"GPU \"{name}\" does not have 3D scaling")
             return False

--- a/jtop/core/gpu.py
+++ b/jtop/core/gpu.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar
 from .common import cat, GenericInterface
 from .exceptions import JtopException
 from .command import Command
+from .hw_detect import is_thor, is_jetpack7
 from .jetson_variables import get_jetson_variables, NVIDIA_JETPACK
 
 T = TypeVar('T')
@@ -213,6 +214,16 @@ def find_igpu(igpu_path):
         path_3d_scaling = os.path.join(path, "enable_3d_scaling")
         if os.path.isfile(path_3d_scaling):
             igpu[name]['3d_scaling'] = path_3d_scaling
+        elif is_jetpack7():
+            # JetPack 7 (Thor-class kernel) drops enable_3d_scaling on Orin.
+            # There 3D scaling is the devfreq governor (performance <->
+            # nvhost_podgov) — the same mechanism Thor uses. Record the
+            # governor node so the service can read/toggle it.
+            gov_path = os.path.join(frq_path, "governor")
+            avail_path = os.path.join(frq_path, "available_governors")
+            if os.path.isfile(gov_path) and 'nvhost_podgov' in (cat(avail_path) if os.path.isfile(avail_path) else ''):
+                igpu[name]['3d_scaling_governor'] = gov_path
+                logger.info(f"GPU \"{name}\" 3D scaling via devfreq governor {gov_path}")
     return igpu
 
 
@@ -528,17 +539,26 @@ class GPUService(object):
 
     def _initialize_gpu_method(self):
         """Initialize GPU monitoring method and return True if using NVML"""
-        # Check if we should use NVML (Jetpack 7.0+)
-        use_nvml = check_jetpack_version() and NVML_AVAILABLE
+        # The real Thor PCIe GPU stack (gpu-gpc-0) exposes no usable nvgpu
+        # sysfs interface and is driven through NVML + the dedicated Thor UI
+        # page. Every other board -- including JetPack 7.x Orin, whose nvgpu
+        # sysfs interface is fully present even though NVML reports almost
+        # nothing (NVMLError_NotSupported for load, clocks, memory, processes)
+        # -- is better served by the traditional sysfs path.
+        if not is_thor():
+            self._initialize_traditional_gpus()
+            if self._gpu_list:
+                logger.info("Using sysfs (devfreq) GPU monitoring")
+                return False
 
-        if use_nvml:
-            if self._try_nvml_init():
-                return True
-            else:
-                logger.info("NVML initialization failed, falling back to traditional method")
+        # Fall back to NVML on JetPack 7.0+ (Thor, or boards without a sysfs iGPU)
+        if check_jetpack_version() and NVML_AVAILABLE and self._try_nvml_init():
+            return True
+        logger.info("NVML unavailable, falling back to traditional method")
 
-        # Use traditional method
-        self._initialize_traditional_gpus()
+        # Last resort: traditional sysfs (covers any board not handled above)
+        if not self._gpu_list:
+            self._initialize_traditional_gpus()
         return False
 
     def _try_nvml_init(self):
@@ -581,6 +601,20 @@ class GPUService(object):
         if self._use_nvml:
             logger.warning("3D scaling control not available via NVML (Jetpack 7.0+)")
             return False
+        # JetPack 7 Orin: 3D scaling is the devfreq governor (no enable_3d_scaling node)
+        if '3d_scaling_governor' in self._gpu_list[name]:
+            gov_path = self._gpu_list[name]['3d_scaling_governor']
+            target = "nvhost_podgov" if value else "performance"
+            try:
+                if os.access(gov_path, os.W_OK):
+                    with open(gov_path, 'w') as f:
+                        f.write(target)
+                    logger.info(f"GPU \"{name}\" set 3D scaling to {value} (governor={target})")
+                else:
+                    logger.error(f"GPU \"{name}\" governor {gov_path} is not writable")
+            except OSError as e:
+                logger.error(f"I cannot set 3D scaling governor {e}")
+            return
         if '3d_scaling' not in self._gpu_list[name]:
             logger.error(f"GPU \"{name}\" does not have 3D scaling")
             return False
@@ -640,6 +674,10 @@ class GPUService(object):
                 if os.access(data['path'] + "/power/control", os.R_OK):
                     with open(data['path'] + "/power/control", 'r') as f:
                         gpu['power_control'] = f.read().strip()
+                # JetPack 7 Orin: 3D scaling state is the devfreq governor
+                if '3d_scaling_governor' in data:
+                    gov = gpu['freq'].get('governor', '')
+                    gpu['status']['3d_scaling'] = bool(gov) and gov != 'performance'
             elif gpu['type'] == 'discrete':
                 logger.info("TODO discrete GPU")
             # Load all status in GPU

--- a/jtop/core/hw_detect.py
+++ b/jtop/core/hw_detect.py
@@ -18,12 +18,55 @@
 # jtop/core/hw_detect.py
 
 import os
+import platform
+import re
 
 THOR_GPC = "/sys/class/devfreq/gpu-gpc-0"
 
+# L4T R38 = JetPack 7.0/7.1, R39 = JetPack 7.2. Everything < R38 is JetPack 6
+# or older.  JetPack 7 ships the Thor-class kernel & userspace even on Jetson
+# Orin (which keeps the classic nvgpu sysfs interface but loses some legacy
+# control nodes such as ``enable_3d_scaling``).
+JETPACK7_L4T_MAJOR = 38
+
 
 def is_thor() -> bool:
+    """True only on the real Thor PCIe GPU stack (gpu-gpc-0 devfreq domain)."""
     return os.path.isdir(THOR_GPC)
+
+
+def is_jetpack7() -> bool:
+    """
+    True on the JetPack 7.x / L4T R38+ OS — the Thor-class kernel and userspace
+    that JetPack 7.2 also ships on Jetson Orin.
+
+    Unlike :func:`is_thor` this is an *OS* check, not a GPU-stack check: a
+    JetPack 7.2 Orin reports True here while still exposing the classic nvgpu
+    sysfs interface (``/sys/class/devfreq/17000000.gpu``) rather than Thor's
+    ``gpu-gpc-0``.
+
+    Detection order:
+      1. ``/etc/nv_tegra_release`` -> ``# R39 (release), ...`` (major >= 38)
+      2. kernel release fallback   -> ``*-tegra`` with version >= 6.8
+    """
+    # 1) L4T release file (authoritative)
+    try:
+        with open("/etc/nv_tegra_release", "r", encoding="utf-8", errors="ignore") as f:
+            first_line = f.readline()
+        match = re.search(r"R(\d+)", first_line)
+        if match:
+            return int(match.group(1)) >= JETPACK7_L4T_MAJOR
+    except Exception:
+        pass
+    # 2) Kernel fallback, e.g. "6.8.12-1021-tegra"
+    try:
+        release = platform.release()
+        if "tegra" in release:
+            major, minor = (int(p) for p in release.split(".")[:2])
+            return (major, minor) >= (6, 8)
+    except Exception:
+        pass
+    return False
 
 
 def devfreq_nodes():

--- a/jtop/gui/pgpu.py
+++ b/jtop/gui/pgpu.py
@@ -74,7 +74,7 @@ class GPU(Page):
             type_gpu = "i" if self.jetson.gpu[gpu_name]['type'] == 'integrated' else 'd'
             chart = Chart(jetson, "{t}GPU {name}".format(t=type_gpu, name=gpu_name), self.update_chart,
                           color_text=curses.COLOR_GREEN)
-            # button_railgate = SmallButton(stdscr, self.action_railgate, info={'name': gpu_name})
+            button_railgate = SmallButton(stdscr, self.action_railgate, info={'name': gpu_name})
             button_3d_scaling = SmallButton(stdscr, self.action_scaling_3D, info={'name': gpu_name})
             if type_gpu == 'i':
                 chart_ram = Chart(jetson, "GPU Shared RAM", self.update_chart_ram,
@@ -83,7 +83,7 @@ class GPU(Page):
                                   color_chart=[COLOR_GREY, curses.COLOR_GREEN])
             else:
                 chart_ram = None
-            self.draw_gpus[gpu_name] = {'chart': chart, '3d_scaling': button_3d_scaling, 'ram': chart_ram}
+            self.draw_gpus[gpu_name] = {'chart': chart, '3d_scaling': button_3d_scaling, 'railgate': button_railgate, 'ram': chart_ram}
         # Add Process table
         self.process_table = ProcessTable(self.stdscr, self.jetson)
 
@@ -180,13 +180,15 @@ class GPU(Page):
                 # NVML mode - show as unavailable
                 plot_name_info(self.stdscr, first + 1 + (idx + 1) * gpu_height - 1, 1 + button_idx, "Railgate", "N/A (NVML)")
             else:
-                # Traditional mode - show status
-                railgate_string = "Active" if gpu_status['railgate'] else "Disable"
-                railgate_status = NColors.green() if gpu_status['railgate'] else curses.A_NORMAL
-                plot_name_info(self.stdscr, first + 1 + (idx + 1) * gpu_height - 1, 1 + button_idx, "Railgate", railgate_string, color=railgate_status)
-            # self.stdscr.addstr(first + 1 + (idx + 1) * gpu_height - 1, 1 + button_idx, "Railgate:", curses.A_BOLD)
-            # self.draw_gpus[gpu_name]['railgate'].update(first + 1 + (idx + 1) * gpu_height - 1, 10 + button_idx, railgate_string,
-            #                                             key=key, mouse=mouse, color=railgate_status)
+                # Traditional mode - clickable toggle
+                railgate_string = "Active" if gpu_status.get('railgate') else "Disable"
+                railgate_status = NColors.green() if gpu_status.get('railgate') else curses.A_NORMAL
+                try:
+                    self.stdscr.addstr(first + 1 + (idx + 1) * gpu_height - 1, 1 + button_idx, "Railgate:", curses.A_BOLD)
+                    self.draw_gpus[gpu_name]['railgate'].update(first + 1 + (idx + 1) * gpu_height - 1, 10 + button_idx,
+                                                                railgate_string, key=key, mouse=mouse, color=railgate_status)
+                except curses.error:
+                    pass
             button_idx += button_position
             # Power control
             plot_name_info(self.stdscr, first + 1 + (idx + 1) * gpu_height - 1, 1 + button_idx, "Power ctrl", gpu_data['power_control'])


### PR DESCRIPTION
```
Fix static GPU controls on JetPack 7.2 Orin (nvgpu sysfs vs NVML)

On JetPack 7.2 (L4T R39.2) the Jetson AGX Orin moves to the Thor-class kernel/userspace but keeps classic nvgpu GPU stack. NVML on Orin nvgpu returns NVMLError_NotSupported for load, clocks, memory and processes — so the GPU page showed a dead "3D scaling: N/A (NVML) / Railgate: N/A (NVML)" row with power_control "nvml".

The classic sysfs interface (/sys/class/devfreq/17000000.gpu) is fully present, except that enable_3d_scaling is gone — on this kernel 3D scaling is the devfreq governor (performance <-> nvhost_podgov), the same mechanism Thor uses.

Changes:
- hw_detect: add is_jetpack7() (L4T R38+ via /etc/nv_tegra_release, kernel fallback) to distinguish the JetPack 7 OS on Orin from the Thor GPU stack.
- core/gpu: prefer the traditional sysfs path whenever a controllable iGPU is present and the board is not Thor; else fall back to NVML. Detect governor-based 3D scaling when enable_3d_scaling is absent, and read/write it through the devfreq governor.
- gui/pgpu: make railgate a clickable toggle (matching 3D scaling) instead of read-only text.

Thor code (gpu-gpc-0 + pgpu_thor) is unchanged. Orin JetPack 6 and older are unchanged.
```

JetPack 7.2 (L4T **R39.2.0**) re-bases Jetson AGX Orin onto sbsa-linux and
(kernel `6.8.12-1021-tegra`), but the GPU remains the **nvgpu** stack:

- `nvidia-smi` reports `Orin (nvgpu)`.
- `/sys/class/devfreq/gpu-gpc-0` (the Thor marker used by `is_thor()`) does
  **not** exist; the classic `/sys/class/devfreq/17000000.gpu` does.

The existing Thor code path and the NVML path fail on Orin JP7.2.

Two issues, both from assuming "JetPack 7 == NVML":

1. `core/gpu.py:GPUService._initialize_gpu_method()` gated purely on
   `check_jetpack_version()` (>= 7.0) and used NVML. On this board NVML returns
   `NVMLError_NotSupported` for utilization, clocks, memory and process lists —
   only the device name works. The NVML path therefore hardcodes
   `3d_scaling=None`, `railgate=None`, `power_control='nvml'`.
2. `gui/pgpu.py` renders `power_control == 'nvml'` as a static
   `3D scaling: N/A (NVML)` / `Railgate: N/A (NVML)` row.

The nvgpu sysfs nodes are alive and (for root) writable:

The one legacy node that is **gone** from Orin JP7.2 is `enable_3d_scaling`; on this kernel 3D
scaling is the devfreq governor (`performance` = off, `nvhost_podgov` = on),
mirroring Thor.

- Added `is_jetpack7()` — an **OS** check (not a GPU-stack check). Reads
  `/etc/nv_tegra_release` (`# R39 ...`, L4T major >= 38 = JetPack 7) with a
  kernel-release fallback (`*-tegra` and version >= 6.8). JetPack 6 (R36) and
  older return `False`.

- `_initialize_gpu_method()`: prefer the traditional sysfs path whenever a
  controllable iGPU is found and the board is **not** real Thor; only fall back
  to NVML for Thor or boards with no sysfs iGPU.
- `find_igpu()`: when `enable_3d_scaling` is absent **and** `is_jetpack7()`,
  record the devfreq `governor` node as the 3D-scaling control
  (`3d_scaling_governor`).
- `get_status()`: derive `3d_scaling` from the governor (`!= performance`) in
  that mode.
- `set_scaling_3D()`: write `nvhost_podgov` / `performance` to the governor in
  that mode.

- Activated `button_railgate` and made the railgate field a clickable
  `[Active]`/`[Disable]` toggle (mirrors 3D scaling) instead of read-only text.
  Uses `.get('railgate')` so boards without the node don't crash.

- **TPC PG**: driven by the **nvpmodel** power model (6CTRL page), not a direct
  GPU toggle — read-only is correct.
- **Power ctrl** (`auto`/`on`): informational; it is the same runtime-PM knob
  as railgate.

- `is_thor()` = `False`, `is_jetpack7()` = `True`.
- `GPUService` selects sysfs (`_use_nvml = False`); `get_status()` returns real
  `load`, `freq`, `railgate`, `power_control='auto'`, and governor-derived
  `3d_scaling`.
- 3D scaling toggles the governor (`performance` <-> `nvhost_podgov`); GPC
  frequency meters render live.
- Railgate write is effective: writing `railgate_enable=0` reads back `0`
  (restored to `1`).
- `python -m py_compile` passes for all three files.

```

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Fix GPU monitoring and controls on JetPack 7.x Orin by preferring the nvgpu sysfs interface over NVML where available and wiring 3D scaling and railgate into the existing UI.

New Features:
- Enable 3D scaling control on JetPack 7.x Orin by mapping the devfreq governor to the 3D scaling toggle when the legacy node is absent.
- Make the GPU railgate field in the UI an interactive toggle instead of read-only text.

Bug Fixes:
- Restore working GPU stats and power controls on JetPack 7.2 Orin where NVML reports limited or unsupported data.

Enhancements:
- Adjust GPU method selection to prefer sysfs-based monitoring on non-Thor boards and only fall back to NVML when necessary.
- Introduce an OS-level JetPack 7 detection helper to distinguish JetPack 7.x from earlier releases and from the Thor GPU stack.