### PR TITLE
add backstop to close() method in JTopServer shutdown

### DIFF
--- a/jtop/service.py
+++ b/jtop/service.py
@@ -668,14 +668,14 @@ class JtopServer(Process):
         self.broadcaster.shutdown()
         # If process is alive wait to quit
         # logger.debug("Status subprocess {status}".format(status=self.is_alive()))
-        while self.is_alive():
-            # If process is in timeout manually terminate
-            if self.interval.value == -1.0:
-                logger.info("Terminate subprocess")
-                self.terminate()
-            logger.info("Wait shutdown subprocess")
+        if self.is_alive():
+            logger.info("Terminate subprocess")
+            self.terminate()
             self.join(timeout=TIMEOUT_SWITCHOFF)
-            self.interval.value = -1.0
+        if self.is_alive():
+            logger.warning("Process did not terminate cleanly, sending SIGKILL")
+            self.kill()
+            self.join(timeout=TIMEOUT_SWITCHOFF)
         # Close tegrastats
         try:
             error = self._error.get(timeout=0.5)


### PR DESCRIPTION
I found an infinite-loop bug on shutdown while repeatedly power cycling the robot I work on at my job. 

In short, the JTopServer would _sometimes_ exit cleanly, showing the two appropriate log messages from l.674 ("Terminate subprocess") and l.676 ("Wait shutdown subprocess") in jtop/service. Other times, the subprocess would not respond to the SIGTERM, putting the JTopServer in a tight infinte loop that would bog the cpu down.

I added a SIGKILL escalation to try and backstop when the subprocess doesn't respond to SIGTERM after the switchoff timeout.

This is my first OSS PR and I'd love to make contributions more often, so I'd appreciate any feedback you might have!

Some logfiles showing the bug's behavior.

Raw log:

<img width="1265" height="1144" alt="image" src="https://github.com/user-attachments/assets/b44a0636-9d02-4b6d-91b3-69e9bb7ad3d7" />

Syslog pared down with `grep "Terminate subprocess\|Wait shutdown subprocess" syslog-bower | awk '{print $1, $2, $3}' | uniq -c`:

<img width="1458" height="774" alt="image" src="https://github.com/user-attachments/assets/ee6dc558-c894-4325-9f0a-15ee328320e5" />

## Summary by Sourcery

Improve JTopServer shutdown to avoid hangs when the subprocess does not respond to SIGTERM.

Bug Fixes:
- Prevent an infinite loop and high CPU usage during JTopServer shutdown when the subprocess fails to terminate on SIGTERM.

Enhancements:
- Add a SIGKILL escalation path in JTopServer.close() to ensure the subprocess is forcefully terminated if it does not exit within the configured timeout.