### PR TITLE
fix upgrade-jtop.sh: handle root-owned pycache from sudo jtop runs

### DIFF
--- a/scripts/upgrade-jtop.sh
+++ b/scripts/upgrade-jtop.sh
@@ -116,30 +116,15 @@ remove_legacy_jtop() {
   fi
 }
 
+sudo -v
 remove_legacy_jtop
-
-# In order to prevent uv from interactively prompting "replace existing venv?" and script error we must
-# remove uv venv where root owned __pycache__/* are written when "sudo jtop" has been run.
-
-clean_stale_venv() {
-  [[ -d "$VENV_DIR" ]] || return 0
-
-  if [[ ! -O "$VENV_DIR" ]] || [[ ! -w "$VENV_DIR" ]]; then
-    echo "Removing stale venv (not owned/writable by $(id -un)): $VENV_DIR"
-    sudo rm -rf "$VENV_DIR"
-    echo "Stale venv removed."
-  fi
-}
-
-clean_stale_venv
 
 # ── Ensure uv and venv exist ───────────────────────────────────────────────
 export PATH="$HOME/.local/bin:$PATH"
 
 if ! command -v uv >/dev/null 2>&1 || [[ ! -d "$VENV_DIR" ]]; then
   echo "uv or jtop venv not found — running full installer..."
-  sudo -v
-  curl -LsSf https://raw.githubusercontent.com/rbonghi/jetson_stats/master/scripts/install_jtop_torun_without_sudo.sh | bash
+  curl -LsSf https://raw.githubusercontent.com/rbonghi/jetson_stats/master/scripts/install_jtop_torun_without_sudo.sh | bash || exit 1
   exit 0
 fi
 
@@ -147,8 +132,7 @@ if [[ ! -x "$JTOP_PYTHON" ]]; then
   echo "Broken jtop venv (Python not found): $JTOP_PYTHON"
   echo "Removing and re-running full installer..."
   sudo rm -rf "$VENV_DIR"
-  sudo -v
-  curl -LsSf https://raw.githubusercontent.com/rbonghi/jetson_stats/master/scripts/install_jtop_torun_without_sudo.sh | bash
+  curl -LsSf https://raw.githubusercontent.com/rbonghi/jetson_stats/master/scripts/install_jtop_torun_without_sudo.sh | bash || exit 1
   exit 0
 fi
 
@@ -164,7 +148,7 @@ else
   echo "$SYSTEMD_SERVICE not found; continuing without stopping service."
 fi
 
-echo "Removing root-owned __pycache__ directories in $VENV_DIR..."
+echo "Removing stale __pycache__ directories in $VENV_DIR..."
 sudo find "$VENV_DIR" \
   -type d -name "__pycache__" -prune \
   -exec rm -rf -- {} + 2>/dev/null || true

--- a/scripts/upgrade-jtop.sh
+++ b/scripts/upgrade-jtop.sh
@@ -33,7 +33,7 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
-# ── Remove legacy system-wide jtop installs ────────────────────────────────
+# Remove legacy system-wide jtop installs
 remove_legacy_jtop() {
   echo "Checking for legacy system jtop installs outside the uv venv..."
 
@@ -118,6 +118,21 @@ remove_legacy_jtop() {
 
 remove_legacy_jtop
 
+# In order to prevent uv from interactively prompting "replace existing venv?" and script error we must
+# remove uv venv where root owned __pycache__/* are written when "sudo jtop" has been run.
+
+clean_stale_venv() {
+  [[ -d "$VENV_DIR" ]] || return 0
+
+  if [[ ! -O "$VENV_DIR" ]] || [[ ! -w "$VENV_DIR" ]]; then
+    echo "Removing stale venv (not owned/writable by $(id -un)): $VENV_DIR"
+    sudo rm -rf "$VENV_DIR"
+    echo "Stale venv removed."
+  fi
+}
+
+clean_stale_venv
+
 # ── Ensure uv and venv exist ───────────────────────────────────────────────
 export PATH="$HOME/.local/bin:$PATH"
 
@@ -129,17 +144,12 @@ if ! command -v uv >/dev/null 2>&1 || [[ ! -d "$VENV_DIR" ]]; then
 fi
 
 if [[ ! -x "$JTOP_PYTHON" ]]; then
-  echo "Existing jtop venv Python not found:"
-  echo "  $JTOP_PYTHON"
-  echo "Run the full installer first."
-  exit 1
-fi
-
-# ── Resolve site-packages path dynamically ────────────────────────────────
-SITE_PACKAGES="$("$JTOP_PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
-if [[ -z "$SITE_PACKAGES" ]]; then
-  echo "Cannot locate site-packages for $JTOP_PYTHON"
-  exit 1
+  echo "Broken jtop venv (Python not found): $JTOP_PYTHON"
+  echo "Removing and re-running full installer..."
+  sudo rm -rf "$VENV_DIR"
+  sudo -v
+  curl -LsSf https://raw.githubusercontent.com/rbonghi/jetson_stats/master/scripts/install_jtop_torun_without_sudo.sh | bash
+  exit 0
 fi
 
 # ── Stop service, clean pycache, upgrade ──────────────────────────────────
@@ -154,19 +164,10 @@ else
   echo "$SYSTEMD_SERVICE not found; continuing without stopping service."
 fi
 
-if [[ -d "$SITE_PACKAGES" ]]; then
-  echo "Removing stale __pycache__ directories under:"
-  echo "  $SITE_PACKAGES"
-  sudo find "$SITE_PACKAGES" \
-    -type d \
-    -name '__pycache__' \
-    -prune \
-    -exec rm -rf {} +
-else
-  echo "site-packages directory not found:"
-  echo "  $SITE_PACKAGES"
-  exit 1
-fi
+echo "Removing root-owned __pycache__ directories in $VENV_DIR..."
+sudo find "$VENV_DIR" \
+  -type d -name "__pycache__" -prune \
+  -exec rm -rf -- {} + 2>/dev/null || true
 
 echo "Upgrading $PKG_NAME from:"
 echo "  $JTOP_REF"


### PR DESCRIPTION
`sudo jtop` writes **root**-owned files into __pycache__ inside the user-owned
   venv, causing uv to fail with permission errors on the next upgrade.

  - Sweep and delete all __pycache__ dirs in $VENV_DIR with sudo before upgrading (replaces the narrower $SITE_PACKAGES-only sweep)
  - Add clean_stale_venv() to silently remove a root-owned venv before calling the installer, preventing uv's interactive "replace venv?" prompt
  - Recover broken venv (missing Python) by re-running the full installer instead of exiting with an error

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Handle stale or broken jtop virtual environments during upgrade and ensure root-owned pycache directories no longer break uv-based upgrades.

Bug Fixes:
- Remove stale or non-writable uv virtual environments before upgrade to avoid uv interactive prompts and permission errors caused by root-owned files from sudo jtop runs.
- Recover from broken jtop virtual environments missing the Python binary by deleting the venv and re-running the full installer.
- Clean all root-owned __pycache__ directories within the jtop venv instead of only under site-packages to prevent upgrade failures.