### PR TITLE
fix(jetson_clocks): handle non-zero exit from `jetson_clocks --show`

### DIFF
--- a/jtop/core/jetson_clocks.py
+++ b/jtop/core/jetson_clocks.py
@@ -523,6 +523,8 @@ class JetsonClocksService(object):
             list_engines = decode_show_message(lines)
         except Command.TimeoutException as e:
             logger.warning("Timeout {}".format(e))
+        except Command.CommandException as e:
+            logger.warning("jetson_clocks --show failed: {}".format(e))
         return list_engines
 
     def store(self):


### PR DESCRIPTION
- Add a `Command.CommandException` handler in `JetsonClocksService.show()` alongside the existing `TimeoutException` handler.
- Any non-zero exit from `jetson_clocks --show` is now logged as a warning instead of propagating and killing the service.

- The show() method only caught Command.TimeoutException, so any non-zero exit (e.g. "Error! GPU frequency scaling not supported!" raised Command.CommandException and crashed jtop.service at startup.

- Catch Command.CommandException as well and log a warning; show() falls back to an empty engine list, which downstream code already handles.

Fixes #876

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Handle non-zero exits from `jetson_clocks --show` without crashing the service by treating them similarly to timeouts and returning an empty engine list.

Bug Fixes:
- Prevent jtop service from crashing at startup when `jetson_clocks --show` exits with a non-zero status by catching the corresponding command exception.
- Log failures from `jetson_clocks --show` as warnings instead of propagating exceptions that terminate the service.