### PR TITLE
sensors: prefix hwmon sensor labels with device name

### DIFF
--- a/jtop/core/temperature.py
+++ b/jtop/core/temperature.py
@@ -80,6 +80,10 @@ def get_hwmon_thermal_system(root_dir):
         path = os.path.join(root_dir, dir)
         if not os.path.isdir(path):
             continue
+        # Read the hwmon device name (e.g. "nvme") so generic labels like
+        # "Composite" or "Sensor 1" can be disambiguated by their source device.
+        device_name_path = os.path.join(path, "name")
+        device_name = cat(device_name_path).strip() if os.path.isfile(device_name_path) else ""
         # Find all pwm in folder
         for file in os.listdir(path):
             name_label_path = os.path.join(path, file)
@@ -92,6 +96,9 @@ def get_hwmon_thermal_system(root_dir):
             number_port = int(parsed_name['num'])
             # Read name
             raw_name = cat(name_label_path).strip()
+            # Prefix with the hwmon device name (e.g. "nvme" + "Sensor 1" -> "nvmeSensor1")
+            if device_name:
+                raw_name = "{dev}{label}".format(dev=device_name, label=re.sub(r'\s+', '', raw_name))
             logger.info("Found temperature sensor: {name}".format(name=raw_name))
             # Build list of path
             path_crit_alarm = os.path.join(path, "temp{num}_crit_alarm".format(num=number_port))

--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -143,14 +143,15 @@ def compact_temperatures(stdscr, pos_y, pos_x, width, height, jetson):
     counter = 0
     center_x = pos_x + width // 2 + 1
     offset = 2
-    # Plot title
+    # Plot title (extra padding before [Temp] so the two headers don't butt together)
     stdscr.addstr(pos_y, center_x - offset - 10, " [Sensor] ", curses.A_BOLD)
-    stdscr.addstr(pos_y, center_x + offset, " [Temp] ", curses.A_BOLD)
+    stdscr.addstr(pos_y, center_x + offset + 2, " [Temp] ", curses.A_BOLD)
     # Plot name and temperatures
     for idx, (name, sensor) in enumerate(jetson.temperature.items()):
         # Plot temperature
         try:
-            color_temperature(stdscr, pos_y + idx + 1, center_x - 5 * offset, name, sensor, offset=4 * offset)
+            # offset=4*offset + 2 shifts the value column to sit flush under the [Temp] header
+            color_temperature(stdscr, pos_y + idx + 1, center_x - 5 * offset, name, sensor, offset=4 * offset + 2)
         except curses.error:
             break
         counter = idx


### PR DESCRIPTION
- jtop/core/temperature.py: prepend the hwmon device name (e.g. `nvme`) to generic temp labels so 
`Composite` / `Sensor 1` / `Sensor 2` render as `nvmeComposite` / `nvmeSensor1` / `nvmeSensor2`. 
Identifies devices that ship with sensors with generic label strings.
- On page 1ALL: in `jtop/gui/pcontrol.py` add padding between `[Sensor]` and `[Temp]` headers, and align the temperature values flush under `[Temp]`.
- Page 6CTRL already sorts and spaces well; left untouched.

- [x] Verified on Orin (1ALL + 6CTRL)
- [x] Verified on Thor (1ALL + 6CTRL)
- [x] Sensor names now resolve as `nvmeComposite` / `nvmeSensor1` / `nvmeSensor2`
- [x] 1ALL `[Temp]` header no longer abuts `[Sensor]`; values aligned under `[Temp]`

## Summary by Sourcery

Prefix hwmon temperature sensor labels with their device name and adjust the compact temperature UI layout for clearer sensor/value alignment.

New Features:
- Disambiguate generic hwmon temperature sensor labels by prefixing them with the associated device name (e.g. nvmeComposite, nvmeSensor1).

Enhancements:
- Improve the compact temperature view by adding spacing between the [Sensor] and [Temp] headers and aligning temperature values directly under the [Temp] column.