### PR TITLE
fix(gui): show all sensors on 6CTRL in short SSH terminals

### DIFF
--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -86,6 +86,7 @@ SENSOR_VALUE_W = 10       # width of the "  NN.NC" temperature column
 SENSOR_COL_GAP = 2        # blank columns between adjacent sensor columns
 SENSOR_COL_W = SENSOR_NAME_W + SENSOR_VALUE_W + SENSOR_COL_GAP
 SENSOR_HEADER_ROWS = 2    # [Sensor] title row + Name/Temp header row
+SENSOR_TITLE = " [Sensor] "
 
 
 def draw_sensor_block_ctrl(stdscr, pos_y: int, pos_x: int, width: int, height: int, jetson) -> int:
@@ -110,8 +111,9 @@ def draw_sensor_block_ctrl(stdscr, pos_y: int, pos_x: int, width: int, height: i
 
     # Centre the [Sensor] title over the actually-used width.
     used_w = n_cols * SENSOR_COL_W - SENSOR_COL_GAP
+    title_x = pos_x + max(0, (used_w - len(SENSOR_TITLE)) // 2)
     try:
-        stdscr.addstr(pos_y, pos_x + max(0, used_w // 2 - 4), " [Sensor] ", curses.A_BOLD)
+        stdscr.addstr(pos_y, title_x, SENSOR_TITLE, curses.A_BOLD)
     except curses.error:
         pass
 
@@ -141,7 +143,9 @@ def draw_sensor_block_ctrl(stdscr, pos_y: int, pos_x: int, width: int, height: i
         except curses.error:
             pass
 
-    rows_used = min(rows_per_col, (len(temps) + n_cols - 1) // n_cols) if n_cols else 0
+    # Top-to-bottom fill means column 0 always holds the most rows, so the
+    # tallest column's row count is simply min(rows_per_col, len(temps)).
+    rows_used = min(rows_per_col, len(temps))
     return SENSOR_HEADER_ROWS + rows_used
 
 

--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -88,6 +88,11 @@ SENSOR_COL_W = SENSOR_NAME_W + SENSOR_VALUE_W + SENSOR_COL_GAP
 SENSOR_HEADER_ROWS = 2    # [Sensor] title row + Name/Temp header row
 SENSOR_TITLE = " [Sensor] "
 
+# Cap each fan's chart height so the gauge can't eat the whole upper third
+# of a short SSH terminal — otherwise the Sensor block at the bottom is
+# left with too few rows to wrap into and most sensors fall off the screen.
+FAN_HEIGHT_MAX = 8
+
 
 def draw_sensor_block_ctrl(stdscr, pos_y: int, pos_x: int, width: int, height: int, jetson) -> int:
     """Draw a compact Sensors block similar to Jetson Power GUI.
@@ -494,11 +499,8 @@ class CTRL(Page):
     def draw(self, key, mouse):
         # Screen size
         height, width, first = self.size_page()
-        # Measure height. Cap each fan's chart so the gauge can't eat the
-        # whole upper third of a short SSH terminal — otherwise the Sensor
-        # block at the bottom is left with too few rows to wrap into and
-        # most sensors fall off the screen.
-        FAN_HEIGHT_MAX = 8
+        # Measure height (FAN_HEIGHT_MAX caps the chart on short terminals;
+        # see the module-level constant for rationale).
         fan_height = (height * 1 // 3 + 2) // len(self.jetson.fan) if len(self.jetson.fan) > 0 else 0
         fan_height = min(fan_height, FAN_HEIGHT_MAX) if fan_height else 0
         # Draw all GPU

--- a/jtop/gui/pcontrol.py
+++ b/jtop/gui/pcontrol.py
@@ -78,44 +78,71 @@ def _collect_temps_for_ctrl(jetson) -> list:
     return sorted(temps, key=lambda t: t[0].lower())
 
 
+# Sensor-block layout constants (single source of truth for column geometry).
+# Multi-column wrapping uses these to compute every x/y offset, so spacing
+# changes only require editing the constants below.
+SENSOR_NAME_W = 18        # width of the name column
+SENSOR_VALUE_W = 10       # width of the "  NN.NC" temperature column
+SENSOR_COL_GAP = 2        # blank columns between adjacent sensor columns
+SENSOR_COL_W = SENSOR_NAME_W + SENSOR_VALUE_W + SENSOR_COL_GAP
+SENSOR_HEADER_ROWS = 2    # [Sensor] title row + Name/Temp header row
+
+
 def draw_sensor_block_ctrl(stdscr, pos_y: int, pos_x: int, width: int, height: int, jetson) -> int:
-    """Draw a compact Sensors block similar to Jetson Power GUI."""
+    """Draw a compact Sensors block similar to Jetson Power GUI.
+
+    When the available height is too small to list every sensor in a single
+    column, the list wraps into additional columns to the right (top-to-bottom,
+    then left-to-right) so users on short SSH terminals still see all sensors.
+    """
     temps = _collect_temps_for_ctrl(jetson)
     if not temps:
         return 0
 
-    # Keep inside available height
-    max_rows = max(0, height - 3)
-    temps = temps[:max_rows] if max_rows else temps[:8]
+    rows_per_col = max(1, height - SENSOR_HEADER_ROWS)
+    max_cols = max(1, (width + SENSOR_COL_GAP) // SENSOR_COL_W)
+    cols_needed = (len(temps) + rows_per_col - 1) // rows_per_col
+    n_cols = max(1, min(max_cols, cols_needed))
 
+    # Truncate only if even the multi-column layout cannot fit every sensor.
+    capacity = rows_per_col * n_cols
+    temps = temps[:capacity]
+
+    # Centre the [Sensor] title over the actually-used width.
+    used_w = n_cols * SENSOR_COL_W - SENSOR_COL_GAP
     try:
-        stdscr.addstr(pos_y, pos_x + width // 2 - 6, " [Sensor] ", curses.A_BOLD)
+        stdscr.addstr(pos_y, pos_x + max(0, used_w // 2 - 4), " [Sensor] ", curses.A_BOLD)
     except curses.error:
         pass
-    pos_y += 1
 
-    # Header
-    try:
-        stdscr.addstr(pos_y, pos_x, f"{'Name':<18} {'Temp (C)':>10}", curses.A_BOLD)
-    except curses.error:
-        pass
-    pos_y += 1
+    header_y = pos_y + 1
+    header_fmt = f"{{:<{SENSOR_NAME_W}}} {{:>{SENSOR_VALUE_W - 1}}}"
+    for col in range(n_cols):
+        cx = pos_x + col * SENSOR_COL_W
+        try:
+            stdscr.addstr(header_y, cx, header_fmt.format("Name", "Temp (C)"), curses.A_BOLD)
+        except curses.error:
+            pass
 
-    for name, c in temps:
-        # Color by thresholds (reuse existing constants)
+    data_y = pos_y + SENSOR_HEADER_ROWS
+    for idx, (name, c) in enumerate(temps):
+        col, row = divmod(idx, rows_per_col)
+        cx = pos_x + col * SENSOR_COL_W
+        cy = data_y + row
+
         color = curses.A_NORMAL
         if c >= TEMPERATURE_CRIT:
             color = NColors.red()
         elif c >= TEMPERATURE_MAX:
             color = NColors.yellow()
         try:
-            stdscr.addstr(pos_y, pos_x, f"{name:<18}", curses.A_NORMAL)
-            stdscr.addstr(pos_y, pos_x + 18, f"{c:>9.1f}C", color)
+            stdscr.addstr(cy, cx, f"{name:<{SENSOR_NAME_W}}", curses.A_NORMAL)
+            stdscr.addstr(cy, cx + SENSOR_NAME_W, f"{c:>{SENSOR_VALUE_W - 1}.1f}C", color)
         except curses.error:
             pass
-        pos_y += 1
 
-    return 2 + len(temps)
+    rows_used = min(rows_per_col, (len(temps) + n_cols - 1) // n_cols) if n_cols else 0
+    return SENSOR_HEADER_ROWS + rows_used
 
 
 def color_temperature(stdscr, pos_y, pos_x, name, sensor, offset=0):
@@ -463,8 +490,13 @@ class CTRL(Page):
     def draw(self, key, mouse):
         # Screen size
         height, width, first = self.size_page()
-        # Measure height
+        # Measure height. Cap each fan's chart so the gauge can't eat the
+        # whole upper third of a short SSH terminal — otherwise the Sensor
+        # block at the bottom is left with too few rows to wrap into and
+        # most sensors fall off the screen.
+        FAN_HEIGHT_MAX = 8
         fan_height = (height * 1 // 3 + 2) // len(self.jetson.fan) if len(self.jetson.fan) > 0 else 0
+        fan_height = min(fan_height, FAN_HEIGHT_MAX) if fan_height else 0
         # Draw all GPU
         for fan_idx, (fan_gui, fan_name) in enumerate(zip(self._fan_gui, self.jetson.fan)):
             gui_chart = self._fan_gui[fan_gui]
@@ -537,10 +569,19 @@ class CTRL(Page):
             power_rows = 6
 
         sensors_y = first + 1 + line_counter + power_rows + 1
-        sensors_x = width_spacing
-        sensors_w = 30 if sensors_x + 30 < width - 1 else max(20, width - sensors_x - 2)
-        sensors_h = max(6, height - sensors_y - 1)
+        # Start at the left margin (sensor block sits below both the NVP
+        # modes panel and the Power table, so there's no horizontal
+        # collision) — this gives multi-column wrap the full screen width
+        # to work with on narrow SSH terminals.
+        sensors_x = 1
+        sensors_w = max(SENSOR_COL_W, width - sensors_x - 2)
+        # Pass the true remaining height (no artificial floor). Inflating
+        # this would make the function lay out rows that fall off the
+        # terminal and get silently clipped, instead of wrapping into more
+        # columns where the data is actually visible.
+        sensors_h = max(0, height - sensors_y - 1)
 
-        draw_sensor_block_ctrl(self.stdscr, sensors_y, sensors_x, sensors_w, sensors_h, self.jetson)
+        if sensors_h >= SENSOR_HEADER_ROWS + 1:
+            draw_sensor_block_ctrl(self.stdscr, sensors_y, sensors_x, sensors_w, sensors_h, self.jetson)
 
 # EOF


### PR DESCRIPTION
On small terminals (e.g. 27x105 Windows-cmd SSH session) the 6CTRL Sensor block was truncated — Orin showed only `cpu`, Thor showed 3 of 8 sensors — even though the same sensors render fine in 1ALL and on a DisplayPort monitor. The block was pinned to a single 30-col column below the Power table with an inflated height floor, so rows past the bottom were silently clipped.

jtop/gui/pcontrol.py only:
  1. Multi-column wrap in draw_sensor_block_ctrl with named layout constants (SENSOR_NAME_W/VALUE_W/COL_GAP/COL_W/HEADER_ROWS) per the reviewer's "consolidate offsets" principle.
  2. Sensor block uses the full screen width starting at x=1 (it sits vertically below NVP modes and the Power table, so no collision).
  3. Pass the real remaining height (no inflated floor of 6) so the function wraps into more columns rather than writing rows that get clipped.
  4. Cap fan_height at FAN_HEIGHT_MAX = 8 so the fan gauge can't eat the whole upper third of short SSH terminals.

Verified on Orin (9/9 sensors) and Thor (8/8 sensors) over SSH from a Windows 11 cmd shell at 27x105.

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Improve the CTRL sensors panel layout so all sensors are visible on narrow SSH terminals.

New Features:
- Support multi-column wrapping for the CTRL sensor block so sensor entries use the full available screen width.

Bug Fixes:
- Prevent sensor rows from being clipped on short SSH terminals by using remaining height and wrapping into additional columns.
- Limit per-fan chart height so fan gauges cannot consume excessive vertical space and hide the sensor block.

Enhancements:
- Centralize sensor column geometry into named layout constants for easier spacing adjustments.
- Only render the CTRL sensor block when there is enough space to show the header and at least one sensor row.