### PR TITLE
engine: treat non-zero clk_rate as online; expose PVA0_VPS on Orin Thor

### DIFF
--- a/jtop/core/engine.py
+++ b/jtop/core/engine.py
@@ -34,8 +34,12 @@ def read_engine(path):
     # Check if access to this file
     if os.access(path + "/clk_rate", os.R_OK):
         with open(path + "/clk_rate", 'r') as f:
-            # Write current engine
-            engine['cur'] = int(f.read()) // 1000
+            rate = int(f.read())
+            engine['cur'] = rate // 1000
+            # Some clocks (e.g. pva0_cpu_axi, pva0_vps on Orin) report
+            # enable_count=0 but still run at a non-zero rate — treat as online.
+            if rate > 0 and not engine.get('online', False):
+                engine['online'] = True
     # Decode clock rate
     max_value = False
     if os.access(path + "/clk_max_rate", os.R_OK):
@@ -55,7 +59,7 @@ def read_engine(path):
 
 class EngineService(object):
 
-    ENGINES = ['ape', 'dla', 'pva', 'vic', 'nvjpg', 'nvenc', 'nvdec', 'se.', 'cvnas', 'msenc', 'ofa']
+    ENGINES = ['ape.', 'dla', 'pva', 'vic', 'nvjpg', 'nvenc', 'nvdec', 'se.', 'cvnas', 'msenc', 'ofa']
 
     def __init__(self):
         # Sort list before start

--- a/jtop/gui/pengine.py
+++ b/jtop/gui/pengine.py
@@ -288,10 +288,10 @@ def pass_thor(engine):
 def pass_orin(engine):
     return [
         add_engine_in_list('APE', engine, 'APE', 'APE') + add_engine_in_list('PVA0a', engine, 'PVA0', 'PVA0_CPU_AXI'),
-        add_engine_in_list('DLA0c', engine, 'DLA0', 'DLA0_CORE') + add_engine_in_list('DLA1c', engine, 'DLA1', 'DLA1_CORE'),
-        add_engine_in_list('NVENC', engine, 'NVENC', 'NVENC') + add_engine_in_list('NVDEC', engine, 'NVDEC', 'NVDEC'),
-        add_engine_in_list('NVJPG', engine, 'NVJPG', 'NVJPG') + add_engine_in_list('NVJPG1', engine, 'NVJPG', 'NVJPG1'),
-        add_engine_in_list('SE', engine, 'SE', 'SE') + add_engine_in_list('VIC', engine, 'VIC', 'VIC'),
+        add_engine_in_list('PVA0v', engine, 'PVA0', 'PVA0_VPS') + add_engine_in_list('DLA0c', engine, 'DLA0', 'DLA0_CORE'),
+        add_engine_in_list('DLA1c', engine, 'DLA1', 'DLA1_CORE') + add_engine_in_list('NVENC', engine, 'NVENC', 'NVENC'),
+        add_engine_in_list('NVDEC', engine, 'NVDEC', 'NVDEC') + add_engine_in_list('NVJPG', engine, 'NVJPG', 'NVJPG'),
+        add_engine_in_list('NVJPG1', engine, 'NVJPG', 'NVJPG1') + add_engine_in_list('SE', engine, 'SE', 'SE') + add_engine_in_list('VIC', engine, 'VIC', 'VIC'),
     ]
 
 


### PR DESCRIPTION
compact view

On both Orin and Thor, PVA sub-clocks (pva0_cpu_axi, pva0_vps) report clk_enable_count=0 even while running at a non-zero rate, so they rendered as [OFF] in jtop. read_engine() now flips 'online' true when clk_rate > 0, which restores correct frequency display.

Also adds a PVA0v cell to pass_orin() so PVA0_VPS appears on the Orin 1ALL compact view, and tightens the APE match from 'ape' to 'ape.' to avoid loose substring matches against sibling debugfs entries (mirrors existing 'se.' style).

Verified on JetPack 7.2 GA (L4T 39.2.0):
  - AGX Thor:  PVA0_CPU_AXI 909MHz, PVA0_VPS 1.2GHz (1ALL + 5ENG)
  - AGX Orin:  PVA0_CPU_AXI 358MHz, PVA0_VPS 512MHz (5ENG)

## Summary by Sourcery

Adjust engine status detection and Orin compact view to correctly reflect PVA clocks and avoid ambiguous engine matching.

New Features:
- Expose the PVA0_VPS clock in the Orin compact (1ALL) engine view.

Bug Fixes:
- Treat engines with non-zero clk_rate as online even when clk_enable_count is zero to restore accurate frequency display.
- Tighten the APE engine debugfs match to avoid unintended substring matches with sibling entries.