### PR TITLE
fix: parse GR3D_FREQ utilization+array form on JetPack 7 Orin

### DIFF
--- a/jtop/core/tegra_parse.py
+++ b/jtop/core/tegra_parse.py
@@ -23,8 +23,14 @@ SWAP_RE = re.compile(r'SWAP (\d+)\/(\d+)(\w)B( ?)\(cached (\d+)(\w)B\)')
 IRAM_RE = re.compile(r'IRAM (\d+)\/(\d+)(\w)B( ?)\(lfb (\d+)(\w)B\)')
 RAM_RE = re.compile(r'RAM (\d+)\/(\d+)(\w)B( ?)\(lfb (\d+)x(\d+)(\w)B\)')
 MTS_RE = re.compile(r'MTS fg (\d+)% bg (\d+)%')
-VALS_PLAIN_RE = re.compile(r'\b([A-Z0-9_]+) ([0-9%@]+)(?=[^/])\b')
-VALS_ARRAY_RE = re.compile(r'\b([A-Z0-9_]+) @\[([0-9,]+)\]')
+# The "(?!%?@\[)" guard makes this regex refuse the array forms outright, so it
+# cannot half-match "GR3D_FREQ 0%@[1300,1300]" as "GR3D_FREQ 0" and silently drop
+# the frequency. VALS_ARRAY_RE owns those; the two regexes are mutually exclusive.
+VALS_PLAIN_RE = re.compile(r'\b([A-Z0-9_]+) ([0-9%@]+)(?!%?@\[)(?=[^/])\b')
+# Matches both array forms:
+#   - Thor          "GR3D_FREQ @[1000,1000,1000]"   (no utilization)
+#   - JetPack 7 Orin "GR3D_FREQ 0%@[1300,1300]"     (utilization + per-GPC array)
+VALS_ARRAY_RE = re.compile(r'\b([A-Z0-9_]+) (?:(\d+)%)?@\[([0-9,]+)\]')
 VAL_FRE_ONLY_RE = re.compile(r'@(\d+)$')
 VAL_FRE_UTIL_RE = re.compile(r'\b(\d+)%@(\d+)')
 CPU_RE = re.compile(r'CPU \[(.*?)\]')
@@ -157,6 +163,12 @@ def VALS(text):
           GR3D is the GPU engine.
           On Thor and Orin, GR3D reports per-GPC frequencies as an array without utilization.
           Y = GR3D frequency in megahertz
+        - GR3D X%@[Y,Y]
+          GR3D is the GPU engine.
+          On JetPack 7 Orin, GR3D reports the utilization together with the per-GPC
+          frequency array.
+          X = Percent of the GR3D that is being used, relative to the current running frequency.
+          Y = GR3D frequency in megahertz
         - MSENC Y
           Y = MSENC frequency in megahertz.
           MSENC is the video hardware encoding engine.
@@ -169,12 +181,18 @@ def VALS(text):
           It is shown only when hardware decoder/encoder engine is used.
     """
     vals = {}
-    # Parse array values (Thor: GR3D_FREQ @[1000,1000,1000])
-    for name, val in re.findall(VALS_ARRAY_RE, text):
+    # Parse array values (Thor: GR3D_FREQ @[1000,1000,1000],
+    # JetPack 7 Orin: GR3D_FREQ 0%@[1300,1300]). VALS_PLAIN_RE is guarded so it
+    # cannot match these, so the two passes are independent of each other.
+    for name, util, val in re.findall(VALS_ARRAY_RE, text):
         # Remove "FREQ" from name and export max if unset
         name = name.split('_')[0] if "FREQ" in name else name
         freqs = [int(v) * 1000 for v in val.split(',')]
-        vals.setdefault(name, {'frq': max(freqs)})
+        status = {'frq': max(freqs)}
+        # JetPack 7 reports the utilization before the per-GPC array
+        if util:
+            status['val'] = int(util)
+        vals.setdefault(name, status)
     # Parse plain values (Orin: GR3D_FREQ 10%@1000)
     for name, val in re.findall(VALS_PLAIN_RE, text):
         # Remove "FREQ" from name and export if unset

--- a/jtop/tests/test_06_tegra_parse.py
+++ b/jtop/tests/test_06_tegra_parse.py
@@ -1,0 +1,90 @@
+# -*- coding: UTF-8 -*-
+# This file is part of the jetson_stats package (https://github.com/rbonghi/jetson_stats or http://rnext.it).
+# Copyright (c) 2019-2026 Raffaello Bonghi.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from ..core.tegra_parse import DATE, VALS, VALS_ARRAY_RE, VALS_PLAIN_RE
+
+# Real tegrastats line from a Jetson AGX Orin Developer Kit running JetPack 7.2
+# (L4T R39.2). GR3D_FREQ carries the utilization *and* the per-GPC frequency array.
+TEGRASTATS_ORIN_JP7 = (
+    "07-25-2026 09:08:28 RAM 20642/62817MB (lfb 1x2MB) "
+    "CPU [23%@2201,10%@2201,4%@2201,14%@2201,30%@2201,18%@2201,10%@2201,10%@2201,33%@2201,7%@2201,5%@2201,27%@2201] "
+    "EMC_FREQ 3%@3199 GR3D_FREQ 12%@[1300,1300] NVENC0 off NVDEC0 off NVJPG0 off NVJPG1 off VIC off OFA off "
+    "NVDLA0 off NVDLA1 off PVA0_FREQ off APE 174 "
+    "cpu@52.968C/52.968C soc2@48.406C/48.406C soc0@49.531C/49.531C gpu@47.625C/47.625C "
+    "VDD_GPU_SOC 5139mW/5139mW/5139mW VDD_CPU_CV 3268mW/3268mW/3268mW VIN_SYS_5V0 5500mW/5500mW/5500mW"
+)
+
+# Thor reports the per-GPC array without any utilization
+TEGRASTATS_THOR = "RAM 4722/7844MB (lfb 1x512kB) EMC_FREQ 2%@1866 GR3D_FREQ @[1000,1000,1000] APE 150"
+
+# Classic Orin / JetPack 6 form: a single utilization and frequency pair
+TEGRASTATS_ORIN_JP6 = "RAM 4722/7844MB (lfb 1x512kB) EMC_FREQ 2%@1866 GR3D_FREQ 10%@1300 APE 150"
+
+
+def test_gr3d_jetpack7_array_with_utilization():
+    """JetPack 7 Orin: "GR3D_FREQ 12%@[1300,1300]" carries both load and clock."""
+    vals = VALS(DATE(TEGRASTATS_ORIN_JP7))
+    assert vals['GR3D'] == {'val': 12, 'frq': 1300000}
+
+
+def test_gr3d_thor_array_without_utilization():
+    """Thor: "GR3D_FREQ @[1000,1000,1000]" has no utilization, only the clock."""
+    vals = VALS(TEGRASTATS_THOR)
+    assert vals['GR3D'] == {'frq': 1000000}
+
+
+def test_gr3d_plain_value():
+    """Orin / JetPack 6: "GR3D_FREQ 10%@1300" is unchanged."""
+    vals = VALS(TEGRASTATS_ORIN_JP6)
+    assert vals['GR3D'] == {'val': 10, 'frq': 1300000}
+
+
+def test_gr3d_zero_utilization_keeps_frequency():
+    """A 0% load must not drop the frequency (0 is a valid utilization)."""
+    vals = VALS("GR3D_FREQ 0%@[1300,1300]")
+    assert vals['GR3D'] == {'val': 0, 'frq': 1300000}
+
+
+def test_plain_regex_cannot_half_match_the_array_form():
+    """VALS_PLAIN_RE must reject "X%@[Y,Y]" outright.
+
+    Without the "(?!%?@\\[)" guard it stops at the "%" and matches "GR3D_FREQ 0",
+    which silently drops the frequency. Rejecting it here is what makes the two
+    passes in VALS() independent, so reordering them cannot reintroduce the bug.
+    """
+    # "APE 174" is the control: it still matches, so an empty GR3D result means
+    # GR3D was rejected specifically, not that the whole regex stopped working.
+    assert VALS_PLAIN_RE.findall("GR3D_FREQ 0%@[1300,1300] APE 174 VIC off") == [('APE', '174')]
+    assert VALS_PLAIN_RE.findall("GR3D_FREQ 12%@[1300,1300] APE 174 VIC off") == [('APE', '174')]
+
+
+def test_array_and_plain_regexes_are_mutually_exclusive():
+    """No field on a real JetPack 7 line may be claimed by both regexes."""
+    text = DATE(TEGRASTATS_ORIN_JP7)
+    array_names = set(name for name, _util, _val in VALS_ARRAY_RE.findall(text))
+    plain_names = set(name for name, _val in VALS_PLAIN_RE.findall(text))
+    assert array_names == {'GR3D_FREQ'}
+    assert not array_names & plain_names
+
+
+def test_other_values_still_parsed_on_jetpack7():
+    """The new GR3D form must not disturb the other fields on the same line."""
+    vals = VALS(DATE(TEGRASTATS_ORIN_JP7))
+    assert vals['EMC'] == {'val': 3, 'frq': 3199000}
+    assert vals['APE'] == {'val': 174}
+    # The timestamp is stripped by DATE() and must not leak in as a value
+    assert '2026' not in vals


### PR DESCRIPTION
On JetPack 7.2 (L4T R39.2) a Jetson AGX Orin reports the GPU engine in a **third** `GR3D_FREQ` format that `VALS()` does not recognise — the utilization percentage *followed by* the per-GPC frequency array:

```
$ sudo tegrastats
07-25-2026 09:08:28 RAM 20642/62817MB (lfb 1x2MB) CPU [23%@2201,10%@2201,...] EMC_FREQ 3%@3199 \
GR3D_FREQ 0%@[1300,1300] NVENC0 off NVDEC0 off ... APE 174 cpu@52.968C/52.968C ...
```

`tegra_parse.py` knows two forms today:

| Form | Example | Added for |
|---|---|---|
| plain | `GR3D_FREQ 10%@1300` | Orin, JetPack 6 |
| array | `GR3D_FREQ @[1000,1000,1000]` | Thor (86bd474) |

The JetPack 7 Orin line matches **neither**:

* `VALS_ARRAY_RE` requires `@[` with no leading percentage, so it does not match at all.
* `VALS_PLAIN_RE` (`([0-9%@]+)(?=[^/])\b`) cannot include `[`, so it backtracks to just `0` and matches `GR3D_FREQ 0`.

The result is that the frequency is dropped entirely and the load is pinned to `0`:

```python
>>> from jtop.core.tegra_parse import VALS
>>> VALS("GR3D_FREQ 0%@[1300,1300]")['GR3D']
{'val': 0}          # before — no 'frq', load stuck at 0
{'val': 0, 'frq': 1300000}   # after
```

## Fix

Make the utilization group optional in `VALS_ARRAY_RE` and emit it next to the frequency when it is present. The array pass still runs before the plain pass, so `setdefault()` keeps the richer value and the partial `GR3D_FREQ 0` plain match is discarded — I added a comment noting that this ordering is now load-bearing.

The two existing formats are untouched: Thor's array still yields `{'frq': ...}` with no `val`, and the JetPack 6 plain form is unchanged.

## Scope — please read before reviewing

**This is a latent fix, not a user-visible one.** `jtop/core/tegrastats.py` is the only importer of `tegra_parse.py`, and nothing in the tree imports `tegrastats.py` any more — jtop 7.x reads GPU/CPU/EMC/thermal data straight from sysfs. So this does **not** change what `jtop` displays.

I am submitting it anyway because the parser is still actively maintained (86bd474 updated it for Thor two releases ago) and it is plainly wrong for current hardware, so it seemed better to fix it than to leave a trap for whoever touches it next. If you would rather retire `tegrastats.py` instead, I am happy to close this or turn it into a removal PR — just say which you prefer.

For context on how this was found: I was chasing GPU load/clocks stuck at 0 on a JetPack 7.2 AGX Orin. That turned out to be the early-boot NVML latch already fixed by #889 (in `master`, not yet on PyPI — 7.2.0 still ships the old `gpu.py`). This parser bug was a separate issue found while confirming that `tegrastats` really did have the data.

## Tests

Added `jtop/tests/test_06_tegra_parse.py` covering all three `GR3D` forms, per the contributing guide's "write a test which shows that the bug was fixed":

* `test_gr3d_jetpack7_array_with_utilization` — new form, asserts both `val` and `frq` (fails before this change)
* `test_gr3d_thor_array_without_utilization` — regression guard for Thor
* `test_gr3d_plain_value` — regression guard for Orin / JetPack 6
* `test_gr3d_zero_utilization_keeps_frequency` — `0%` is a valid load and must not drop the clock
* `test_other_values_still_parsed_on_jetpack7` — `EMC`/`APE` on the same line are unaffected and the stripped timestamp does not leak in as a value

The JetPack 7 sample is a real `tegrastats` line from the board below. `flake8 .` is clean and `autopep8 --aggressive --aggressive --max-line-length 180` (the CI auto-style step) produces no diff on either file.

## Environment

* **Board:** NVIDIA Jetson AGX Orin Developer Kit (64 GB)
* **Jetpack:** 7.2 GA
* **L4T:** 39.2.0 (R39, REVISION 2.0)
* **Kernel:** 6.8.12-1021-tegra
* **jetson-stats:** `master` @ 844022e
* **Python:** 3.12


<img width="1014" height="640" alt="screenshot_20260725_094004" src="https://github.com/user-attachments/assets/6ee16ad3-4bd4-4f54-a721-803d86765930" />

## Summary by Sourcery

Handle GR3D tegrastats output that includes both utilization and a per-GPC frequency array, ensuring correct parsing for JetPack 7 Orin while preserving existing formats.

Bug Fixes:
- Fix GR3D_FREQ parsing so JetPack 7 Orin utilization-plus-array lines correctly expose both load and frequency instead of pinning load at zero.

Enhancements:
- Document the new GR3D_FREQ utilization-plus-array format alongside existing Thor and Orin formats in the tegra stats parser.

Tests:
- Add tests covering all three GR3D_FREQ formats, including JetPack 7 utilization-plus-array, Thor array-only, Orin plain utilization form, zero-utilization handling, and non-GR3D fields on the same line.