### PR TITLE
feat(7INFO): add static CPU section to 7INFO page

### DIFF
--- a/jtop/core/hardware.py
+++ b/jtop/core/hardware.py
@@ -28,6 +28,206 @@ except ImportError:
 # Create logger
 logger = logging.getLogger(__name__)
 
+# (implementer_id, part_id) -> (model_name, isa_string)
+_ARM_CPU_PARTS = {
+    (0x41, 0xd03): ("Cortex-A53", "Armv8-A"),
+    (0x41, 0xd07): ("Cortex-A57", "Armv8-A"),
+    (0x41, 0xd08): ("Cortex-A72", "Armv8-A"),
+    (0x41, 0xd09): ("Cortex-A73", "Armv8-A"),
+    (0x41, 0xd0a): ("Cortex-A75", "Armv8.2-A"),
+    (0x41, 0xd0b): ("Cortex-A76", "Armv8.2-A"),
+    (0x41, 0xd0c): ("Neoverse N1", "Armv8.2-A"),
+    (0x41, 0xd0d): ("Cortex-A77", "Armv8.2-A"),
+    (0x41, 0xd0e): ("Cortex-A76AE", "Armv8.2-A"),
+    (0x41, 0xd40): ("Neoverse V1", "Armv8.4-A"),
+    (0x41, 0xd41): ("Cortex-A78", "Armv8.2-A"),
+    (0x41, 0xd42): ("Cortex-A78AE", "Armv8.2-A"),
+    (0x41, 0xd44): ("Cortex-X1", "Armv8.2-A"),
+    (0x41, 0xd46): ("Cortex-A510", "Armv9-A"),
+    (0x41, 0xd47): ("Cortex-A710", "Armv9-A"),
+    (0x41, 0xd48): ("Cortex-X2", "Armv9-A"),
+    (0x41, 0xd49): ("Neoverse N2", "Armv9-A"),
+    (0x41, 0xd4d): ("Cortex-A715", "Armv9-A"),
+    (0x41, 0xd4e): ("Cortex-X3", "Armv9-A"),
+    (0x41, 0xd4f): ("Cortex-X4", "Armv9.2-A"),
+    (0x41, 0xd80): ("Cortex-A520", "Armv9.2-A"),
+    (0x41, 0xd81): ("Cortex-A720", "Armv9.2-A"),
+    (0x41, 0xd83): ("Neoverse V3AE", "Armv9.2-A"),
+    (0x41, 0xd84): ("Neoverse V3", "Armv9.2-A"),
+    (0x4e, 0x004): ("Carmel", "Armv8.2-A"),
+}
+
+
+def _parse_first_cpuinfo_block():
+    info = {}
+    try:
+        with open('/proc/cpuinfo', 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line and info:
+                    break
+                if ':' in line:
+                    key, _, val = line.partition(':')
+                    info[key.strip()] = val.strip()
+    except OSError:
+        pass
+    return info
+
+
+def _count_online_cpus():
+    try:
+        with open('/sys/devices/system/cpu/online', 'r') as f:
+            data = f.read().strip()
+        count = 0
+        for part in data.split(','):
+            if '-' in part:
+                lo, hi = part.split('-')
+                count += int(hi) - int(lo) + 1
+            else:
+                count += 1
+        return count
+    except (OSError, ValueError):
+        return os.cpu_count() or 1
+
+
+def _read_cache_total(num_cpus):
+    cache = {}
+    base = '/sys/devices/system/cpu/cpu0/cache'
+    try:
+        indexes = sorted(os.listdir(base))
+    except OSError:
+        return cache
+    for idx in indexes:
+        idx_path = os.path.join(base, idx)
+        try:
+            level = int(open(os.path.join(idx_path, 'level')).read().strip())
+            ctype = open(os.path.join(idx_path, 'type')).read().strip()
+            raw = open(os.path.join(idx_path, 'size')).read().strip()
+        except OSError:
+            continue
+        mults = {'K': 1024, 'M': 1024 * 1024, 'G': 1024 * 1024 * 1024}
+        try:
+            size_bytes = int(raw[:-1]) * mults[raw[-1]] if raw[-1] in mults else int(raw)
+        except (ValueError, IndexError):
+            continue
+        total = size_bytes * num_cpus
+        if level == 1 and ctype == 'Data':
+            cache['L1 Data Cache'] = str(total)
+        elif level == 1 and ctype == 'Instruction':
+            cache['L1 Instruction Cache'] = str(total)
+        elif level == 2:
+            cache['L2 Cache'] = str(total)
+        elif level == 3:
+            cache['L3 Cache'] = str(total)
+    return cache
+
+
+def _decode_arm_features(features_str):
+    feats = set(features_str.lower().split())
+    result = {}
+
+    vec = []
+    if 'asimd' in feats or 'neon' in feats:
+        vec.append('NEON')
+    if 'sve' in feats:
+        vec.append('SVE')
+    if 'sve2' in feats:
+        vec.append('SVE2')
+    if vec:
+        result['Vector ISA'] = ', '.join(vec)
+
+    try:
+        with open('/proc/sys/abi/sve_default_vector_length', 'r') as f:
+            result['SVE vector size'] = '{} bits'.format(int(f.read().strip()) * 8)
+    except (OSError, ValueError):
+        pass
+
+    num = []
+    if 'fphp' in feats or 'fp' in feats:
+        num.append('FP16')
+    if 'bf16' in feats or 'svebf16' in feats:
+        num.append('BF16')
+    if num:
+        result['Numeric formats'] = ', '.join(num)
+
+    iml = []
+    if 'asimddp' in feats:
+        iml.append('INT8 Dot Product')
+    if 'i8mm' in feats or 'svei8mm' in feats:
+        iml.append('INT8 Matrix Multiply')
+    if iml:
+        result['Integer ML'] = ', '.join(iml)
+
+    if 'lse' in feats or 'atomics' in feats:
+        result['Atomics'] = 'Arm LSE'
+
+    sec = []
+    if 'paca' in feats or 'pacg' in feats:
+        sec.append('PAC')
+    if 'bti' in feats:
+        sec.append('BTI')
+    if 'dit' in feats:
+        sec.append('DIT')
+    if 'ssbs' in feats:
+        sec.append('SSBS')
+    if 'sb' in feats:
+        sec.append('SB')
+    if sec:
+        result['Security'] = ', '.join(sec)
+
+    cryp = []
+    if 'aes' in feats or 'sveaes' in feats:
+        cryp.append('AES')
+    if 'sha1' in feats:
+        cryp.append('SHA-1')
+    sha_vers = [v for f, v in [('sha2', '2'), ('sha3', '3'), ('sha512', '512')]
+                if f in feats or 'sve' + f in feats]
+    if sha_vers:
+        cryp.append('SHA-{}'.format('/'.join(sha_vers)))
+    if 'sm3' in feats:
+        cryp.append('SM3')
+    if 'sm4' in feats or 'svesm4' in feats:
+        cryp.append('SM4')
+    if 'crc32' in feats:
+        cryp.append('CRC32')
+    if cryp:
+        result['Cryptography'] = ', '.join(cryp)
+
+    return result
+
+
+def get_cpu_static_info():
+    """Collect static AArch64 CPU info from /proc/cpuinfo and sysfs."""
+    if platform.machine() != 'aarch64':
+        return {}
+    cpuinfo = _parse_first_cpuinfo_block()
+    if not cpuinfo:
+        return {}
+    num_cpus = _count_online_cpus()
+    try:
+        implementer = int(cpuinfo.get('CPU implementer', '0x0'), 16)
+        variant = int(cpuinfo.get('CPU variant', '0x0'), 16)
+        part = int(cpuinfo.get('CPU part', '0x0'), 16)
+        revision = int(cpuinfo.get('CPU revision', '0'), 10)
+    except ValueError:
+        implementer, variant, part, revision = 0, 0, 0, 0
+    # MIDR_EL1: [31:24]=implementer [23:20]=variant [19:16]=0xf [15:4]=part [3:0]=revision
+    midr = (implementer << 24) | (variant << 20) | (0xf << 16) | (part << 4) | revision
+    model_name, isa_string = _ARM_CPU_PARTS.get((implementer, part), (None, None))
+    if not model_name:
+        model_name = '0x{:04x}'.format(part)
+    arch = '{}'.format(isa_string) if isa_string else 'AArch64'
+    result = {
+        'Model': 'Arm {}'.format(model_name),
+        'Architecture': arch,
+        'Configuration': '{} cores'.format(num_cpus),
+        'Revision': 'r{}p{}'.format(variant, revision),
+        'MIDR': '0x{:08x}'.format(midr),
+    }
+    result.update(_decode_arm_features(cpuinfo.get('Features', '')))
+    result.update(_read_cache_total(num_cpus))
+    return result
+
 
 def get_parameter(path):
     if os.path.isfile(path):

--- a/jtop/gui/pinfo.py
+++ b/jtop/gui/pinfo.py
@@ -32,6 +32,24 @@ COPYRIGHT_RE = re.compile(r""".*__copyright__ = ["'](.*?)['"]""", re.S)
 EMAIL_RE = re.compile(r""".*__email__ = ["'](.*?)['"]""", re.S)
 
 
+def plot_cpu_info(stdscr, pos_y, pos_x, cpu_info):
+    KEY_W = 22
+    try:
+        stdscr.addstr(pos_y, pos_x, 'CPU', curses.A_BOLD)
+    except curses.error:
+        pass
+    for idx, (name, value) in enumerate(cpu_info.items()):
+        try:
+            stdscr.addstr(pos_y + idx + 1, pos_x + 1, name + ':', curses.A_BOLD)
+        except curses.error:
+            pass
+        try:
+            stdscr.addstr(pos_y + idx + 1, pos_x + 1 + KEY_W, value, curses.A_NORMAL)
+        except curses.error:
+            pass
+    return len(cpu_info) + 1
+
+
 def plot_libraries(stdscr, pos_y, pos_x, libraries):
     libraries = deepcopy(libraries)
     opencv = libraries['OpenCV']
@@ -99,27 +117,31 @@ class INFO(Page):
         platform_size_y, platform_size_x = plot_dictionary(self.stdscr, start_pos, 1, 'Platform', self.jetson.board['platform'])
         # Plot libraries
         libraries_size_y, libraries_size_x = plot_libraries(self.stdscr, start_pos + platform_size_y + 1, 1, self.jetson.board['libraries'])
+        # Plot CPU static info
+        cpu_info = self.jetson.board.get('cpu', {})
+        if cpu_info:
+            plot_cpu_info(self.stdscr, start_pos + platform_size_y + 1 + libraries_size_y + 1, 1, cpu_info)
         # Plot hardware
-        size_hardware_x = width - platform_size_x - 2
+        right_col_x = 1 + platform_size_x + 7
+        size_hardware_x = width - right_col_x - 1
         # Plot serial number
         offset_y_sn = 0
         if 'Serial Number' in self.jetson.board['hardware']:
             if self.jetson.board['hardware']['Serial Number']:
                 try:
-                    self.stdscr.addstr(start_pos, 1 + platform_size_x + 1, "Serial Number:", curses.A_BOLD)
+                    self.stdscr.addstr(start_pos, right_col_x, "Serial Number:", curses.A_BOLD)
                 except curses.error:
                     pass
-                self._hide_serial_number.update(start_pos, 1 + platform_size_x + 16, key=key, mouse=mouse)
+                self._hide_serial_number.update(start_pos, right_col_x + 15, key=key, mouse=mouse)
                 offset_y_sn = 1
         hardware_size_y, hardware_size_x = plot_hardware(self.stdscr,
                                                          start_pos + offset_y_sn,
-                                                         1 + platform_size_x + 1,
+                                                         right_col_x,
                                                          self.jetson.board['hardware'], size_hardware_x)
         hardware_size_y += offset_y_sn
         # Plot interfaces
         interfaces = self.jetson.local_interfaces["interfaces"]
         hostname = self.jetson.local_interfaces["hostname"]
-        max_size_x = max(platform_size_x, libraries_size_x)
-        plot_name_info(self.stdscr, start_pos + hardware_size_y + 1, 2 + max_size_x, "Hostname", hostname)
-        interfaces_size_y, interfaces_size_x = plot_dictionary(self.stdscr, start_pos + hardware_size_y + 2, 2 + max_size_x, 'Interfaces', interfaces)
+        plot_name_info(self.stdscr, start_pos + hardware_size_y + 1, right_col_x, "Hostname", hostname)
+        interfaces_size_y, interfaces_size_x = plot_dictionary(self.stdscr, start_pos + hardware_size_y + 2, right_col_x, 'Interfaces', interfaces)
 # EOF

--- a/jtop/jtop.py
+++ b/jtop/jtop.py
@@ -1152,6 +1152,8 @@ sudo jtop --install-service""".format(
         self._server_interval = init['interval']
         # Load board information
         self._board['hardware'] = init['board']['hardware']
+        if 'cpu' in init['board']:
+            self._board['cpu'] = init['board']['cpu']
         # Initialize gpu controller
         self._gpu._initialize(self._controller)
         # Initialize memory controller

--- a/jtop/service.py
+++ b/jtop/service.py
@@ -37,7 +37,7 @@ from typing import Optional, Dict, Any
 # jetson_stats imports
 from .core.exceptions import JtopException
 from .core.common import get_key, get_var, get_uptime
-from .core.hardware import get_hardware, get_platform_variables
+from .core.hardware import get_hardware, get_platform_variables, get_cpu_static_info
 from .core.command import Command
 from .core.config import Config
 from .core.timer_reader import TimerReader
@@ -417,7 +417,7 @@ class JtopServer(Process):
         # Load board and platform variables
         data_platform = get_platform_variables()
         logger.info("Running on Python: {python_version}".format(python_version=data_platform['Python']))
-        self.board = {'hardware': get_hardware()}
+        self.board = {'hardware': get_hardware(), 'cpu': get_cpu_static_info()}
         # From this point are initialized or hardware services
         # Setup cpu service
         self.cpu = CPUService()


### PR DESCRIPTION
Collects AArch64 CPU attributes (model, architecture, MIDR, vector ISA, SVE vector size, cache sizes, security/crypto features) at service startup from /proc/cpuinfo and sysfs, then displays them in a new CPU block below Libraries on the 7INFO page.

## Summary by Sourcery

Add collection of static AArch64 CPU attributes at service startup and display them as a dedicated CPU section on the 7INFO page.

New Features:
- Expose a static CPU info block on the 7INFO UI, showing model, architecture, core count, revision, MIDR, vector ISA, cache sizes, and security/crypto capabilities.

Enhancements:
- Extend board metadata to include CPU static information sourced from /proc/cpuinfo and sysfs so it is available to both service and UI layers.