### PR TITLE
fix(3CPU): add blank separator row between Frq and next CPU block

### DIFF
--- a/jtop/gui/pcpu.py
+++ b/jtop/gui/pcpu.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import curses
+from math import ceil
 # Page class definition
 from .jtopgui import Page
 from .lib.chart import Chart
@@ -54,17 +55,64 @@ def cpu_gauge(stdscr, idx, cpu, pos_y, pos_x, _, size_w):
     basic_gauge(stdscr, pos_y, pos_x, size_w - 8, data)
 
 
-def cpu_grid(stdscr, list_cpu, print_cpu, start_y, start_x, size_height=0, size_width=0):
+CPU_TILE_MIN_HEIGHT = 7
+CPU_TILE_MIN_WIDTH = 20
+CPU_TILE_TARGET_RATIO = 3.5
+
+
+def cpu_grid_columns(num_cpu, size_height, size_width):
+    """Choose a grid that follows the terminal aspect ratio.
+
+    The old fixed four-column layout works well in a tall terminal, but makes
+    each CPU chart too short in a wide, shallow SSH terminal. Prefer layouts
+    whose cells are close to the proportions of the normal CPU chart while
+    preserving enough rows and columns for its labels and frequency gauge.
+    """
+    if num_cpu <= 0:
+        return 0
+    if size_height <= 0 or size_width <= 0:
+        return 4 if num_cpu > 6 else 2
+
+    layouts = []
+    fallback = []
+    for columns in range(1, num_cpu + 1):
+        rows = int(ceil(float(num_cpu) / columns))
+        step_height = max(1, size_height // rows)
+        step_width = max(1, size_width // columns)
+        empty_slots = rows * columns - num_cpu
+        ratio_error = abs((float(step_width) / step_height) - CPU_TILE_TARGET_RATIO)
+        candidate = (ratio_error, empty_slots, columns)
+
+        if step_height >= CPU_TILE_MIN_HEIGHT and step_width >= CPU_TILE_MIN_WIDTH:
+            layouts.append(candidate)
+
+        height_deficit = max(0, CPU_TILE_MIN_HEIGHT - step_height)
+        width_deficit = max(0, CPU_TILE_MIN_WIDTH - step_width)
+        fallback.append((height_deficit + width_deficit, ratio_error, empty_slots, columns))
+
+    if layouts:
+        return min(layouts)[2]
+    return min(fallback)[3]
+
+
+def cpu_grid(stdscr, list_cpu, print_cpu, start_y, start_x, size_height=0,
+             size_width=0, size_columns=None):
     num_cpu = len(list_cpu)
     if num_cpu == 0:
         return size_height, size_width, 0, 0
-    size_columns = 4 if num_cpu > 6 else 2
+    if size_columns is None:
+        # Keep the historical layout for compact_cpus() and other callers.
+        size_columns = 4 if num_cpu > 6 else 2
+        size_rows = int(ceil(float(num_cpu) / size_columns))
+        size_columns = int(ceil(float(num_cpu) / size_rows))
+    else:
+        size_columns = max(1, min(size_columns, num_cpu))
+        size_rows = int(ceil(float(num_cpu) / size_columns))
     # Measure size rows and columns
-    size_rows = int(num_cpu / size_columns) + bool((num_cpu / size_columns) % 1)
-    size_columns = int(num_cpu / size_rows) + bool((num_cpu / size_rows) % 1)
-    # Measure step height and width
-    step_height = int(round(size_height / size_rows)) if size_height > 0 else 1
-    step_width = int(size_width / size_columns) if size_width > 0 else 1
+    # Measure step height and width. Floor division guarantees the final row
+    # stays above the page footer; round() could make the grid one row too tall.
+    step_height = max(1, size_height // size_rows) if size_height > 0 else 1
+    step_width = max(1, size_width // size_columns) if size_width > 0 else 1
     # Build Grid
     idx_row = 0
     idx_column = 0
@@ -105,22 +153,16 @@ class CPU(Page):
         }
 
     def print_cpu(self, stdscr, idx, cpu, pos_y, pos_x, size_h, size_w):
-        # Slot layout — last row (pos_y + size_h) is left blank as a separator:
-        #   pos_y .. row_chart  chart
-        #   row_model           model name
-        #   row_freq            freq gauge
-        row_chart = pos_y + size_h - 3
-        row_model = pos_y + size_h - 2
-        row_freq = pos_y + size_h - 1
+        # Slot layout (pos_y + size_h is the blank separator, never drawn into):
+        #   pos_y … row_chart-1  chart body (amplitude history)
+        #   row_chart            time axis   (L -6s  L -4s  L -2s  0)
+        #   row_freq             freq gauge
+        row_chart = pos_y + size_h - 2
+        row_freq  = pos_y + size_h - 1
         governor = cpu.get('governor', '').capitalize()
         label_chart_cpu = "{percent: >3.0f}% {governor}".format(percent=100 - cpu.get('idle', 100), governor=governor)
         chart = self._chart_cpus[idx]
         chart.draw(stdscr, [pos_x, pos_x + size_w], [pos_y, row_chart], label=label_chart_cpu, y_label=False)
-        model = (cpu.get('model', '') or '')[:size_w]
-        try:
-            stdscr.addstr(row_model, pos_x, model, curses.A_NORMAL)
-        except curses.error:
-            pass
         if 'freq' in cpu:
             freq = cpu['freq']
             freq['online'] = cpu['online']
@@ -137,11 +179,23 @@ class CPU(Page):
         total = self.jetson.cpu['total']
         total['name'] = 'ALL'
         cpu_gauge(self.stdscr, 0, total, first + 1, 1, '', width)
-        # Print all GRID CPU
+        # Print all GRID CPU. Select the column count from the current terminal
+        # dimensions so a wide, shallow SSH window uses more columns and fewer
+        # rows instead of collapsing each chart vertically.
+        grid_height = max(1, height - 4)
+        grid_width = max(1, width - 8)
+        size_columns = cpu_grid_columns(len(self.jetson.cpu['cpu']), grid_height, grid_width)
         step_height, step_width, size_columns, size_rows = cpu_grid(
-            self.stdscr, self.jetson.cpu['cpu'], self.print_cpu, first + 2, 1, size_height=height - 4, size_width=width - 8)
-        # Print CPU Y axis
-        chart = self._chart_cpus[0]
-        for i in range(size_rows):
-            chart.draw_y_axis(self.stdscr, first + 2 + i * step_height, 1 + step_width * size_columns, step_height - 3)
+            self.stdscr, self.jetson.cpu['cpu'], self.print_cpu, first + 2, 1,
+            size_height=grid_height, size_width=grid_width, size_columns=size_columns)
+        # Print CPU Y axis. The uploaded Thor layout ends the chart at
+        # pos_y + step_height - 3, so the shared Y axis must use the same end.
+        if step_height >= 5:
+            chart = self._chart_cpus[0]
+            for i in range(size_rows):
+                chart.draw_y_axis(
+                    self.stdscr,
+                    first + 2 + i * step_height,
+                    1 + step_width * size_columns,
+                    step_height - 3)
 # EOF

--- a/jtop/gui/pcpu.py
+++ b/jtop/gui/pcpu.py
@@ -158,7 +158,7 @@ class CPU(Page):
         #   row_chart            time axis   (L -6s  L -4s  L -2s  0)
         #   row_freq             freq gauge
         row_chart = pos_y + size_h - 2
-        row_freq  = pos_y + size_h - 1
+        row_freq = pos_y + size_h - 1
         governor = cpu.get('governor', '').capitalize()
         label_chart_cpu = "{percent: >3.0f}% {governor}".format(percent=100 - cpu.get('idle', 100), governor=governor)
         chart = self._chart_cpus[idx]

--- a/jtop/gui/pcpu.py
+++ b/jtop/gui/pcpu.py
@@ -111,7 +111,7 @@ class CPU(Page):
         #   row_freq            freq gauge
         row_chart = pos_y + size_h - 3
         row_model = pos_y + size_h - 2
-        row_freq  = pos_y + size_h - 1
+        row_freq = pos_y + size_h - 1
         governor = cpu.get('governor', '').capitalize()
         label_chart_cpu = "{percent: >3.0f}% {governor}".format(percent=100 - cpu.get('idle', 100), governor=governor)
         chart = self._chart_cpus[idx]

--- a/jtop/gui/pcpu.py
+++ b/jtop/gui/pcpu.py
@@ -108,23 +108,25 @@ class CPU(Page):
         # Print status CPU
         governor = cpu.get('governor', '').capitalize()
         label_chart_cpu = "{percent: >3.0f}% {governor}".format(percent=100 - cpu.get('idle', 100), governor=governor)
-        # Print chart
+        # Print chart — stop 3 rows before the slot boundary so model and Frq
+        # each get a row, leaving a blank separator row before the next CPU.
         chart = self._chart_cpus[idx]
-        chart.draw(stdscr, [pos_x, pos_x + size_w], [pos_y, pos_y + size_h - 2], label=label_chart_cpu, y_label=False)
+        chart.draw(stdscr, [pos_x, pos_x + size_w], [pos_y, pos_y + size_h - 3], label=label_chart_cpu, y_label=False)
         # Print model
         model = cpu['model'] if 'model' in cpu else ''
         model = model[:size_w]
         try:
-            stdscr.addstr(pos_y + size_h - 1, pos_x, model, curses.A_NORMAL)
+            stdscr.addstr(pos_y + size_h - 2, pos_x, model, curses.A_NORMAL)
         except curses.error:
             pass
-        # Print info
+        # Print info — one row above the slot boundary so the blank boundary
+        # row acts as visual separation from the next CPU block.
         if 'freq' in cpu:
             freq = cpu['freq']
             freq['online'] = cpu['online']
             freq['name'] = "Frq"
             try:
-                freq_gauge(stdscr, pos_y + size_h, pos_x, size_w, cpu['freq'])
+                freq_gauge(stdscr, pos_y + size_h - 1, pos_x, size_w, cpu['freq'])
             except curses.error:
                 pass
 

--- a/jtop/gui/pcpu.py
+++ b/jtop/gui/pcpu.py
@@ -105,28 +105,28 @@ class CPU(Page):
         }
 
     def print_cpu(self, stdscr, idx, cpu, pos_y, pos_x, size_h, size_w):
-        # Print status CPU
+        # Slot layout — last row (pos_y + size_h) is left blank as a separator:
+        #   pos_y .. row_chart  chart
+        #   row_model           model name
+        #   row_freq            freq gauge
+        row_chart = pos_y + size_h - 3
+        row_model = pos_y + size_h - 2
+        row_freq  = pos_y + size_h - 1
         governor = cpu.get('governor', '').capitalize()
         label_chart_cpu = "{percent: >3.0f}% {governor}".format(percent=100 - cpu.get('idle', 100), governor=governor)
-        # Print chart — stop 3 rows before the slot boundary so model and Frq
-        # each get a row, leaving a blank separator row before the next CPU.
         chart = self._chart_cpus[idx]
-        chart.draw(stdscr, [pos_x, pos_x + size_w], [pos_y, pos_y + size_h - 3], label=label_chart_cpu, y_label=False)
-        # Print model
-        model = cpu['model'] if 'model' in cpu else ''
-        model = model[:size_w]
+        chart.draw(stdscr, [pos_x, pos_x + size_w], [pos_y, row_chart], label=label_chart_cpu, y_label=False)
+        model = (cpu.get('model', '') or '')[:size_w]
         try:
-            stdscr.addstr(pos_y + size_h - 2, pos_x, model, curses.A_NORMAL)
+            stdscr.addstr(row_model, pos_x, model, curses.A_NORMAL)
         except curses.error:
             pass
-        # Print info — one row above the slot boundary so the blank boundary
-        # row acts as visual separation from the next CPU block.
         if 'freq' in cpu:
             freq = cpu['freq']
             freq['online'] = cpu['online']
             freq['name'] = "Frq"
             try:
-                freq_gauge(stdscr, pos_y + size_h - 1, pos_x, size_w, cpu['freq'])
+                freq_gauge(stdscr, row_freq, pos_x, size_w, cpu['freq'])
             except curses.error:
                 pass
 


### PR DESCRIPTION
3CPU `Frq` row was drawn at the last row of each CPU slot, immediately above the next CPU header, making it visually ambiguous. 

Move both the model row and Frq row one row earlier within the slot so the slot boundary row is always blank — acting as a clear separator on Orin and also bringing all 14 Frq rows on-screen for Thor (previously the bottom row's Frq was clipped just outside the terminal bounds).

## Summary by Sourcery

Bug Fixes:
- Ensure the 3CPU frequency row is fully visible within terminal bounds and no longer visually merges with the following CPU header.