### PR TITLE
fix(sensor): add space between device name and label for hwmon sensors

### DIFF
--- a/jtop/core/temperature.py
+++ b/jtop/core/temperature.py
@@ -96,9 +96,9 @@ def get_hwmon_thermal_system(root_dir):
             number_port = int(parsed_name['num'])
             # Read name
             raw_name = cat(name_label_path).strip()
-            # Prefix with the hwmon device name (e.g. "nvme" + "Sensor 1" -> "nvmeSensor1")
+            # Prefix with the hwmon device name (e.g. "nvme" + "Composite" -> "nvme Composite")
             if device_name:
-                raw_name = "{dev}{label}".format(dev=device_name, label=re.sub(r'\s+', '', raw_name))
+                raw_name = "{dev} {label}".format(dev=device_name, label=raw_name.strip())
             logger.info("Found temperature sensor: {name}".format(name=raw_name))
             # Build list of path
             path_crit_alarm = os.path.join(path, "temp{num}_crit_alarm".format(num=number_port))


### PR DESCRIPTION
The hwmon sensor name was built as "{device}{label}" with spaces stripped, producing names like "nvmeComposite". 

Change to "{device} {label}" so the `Sensor` block in 1ALL and 6CTRL displays "nvme Composite" instead.

## Summary by Sourcery

Bug Fixes:
- Fix hwmon sensor name formatting so device name and label are separated by a space instead of being concatenated without spaces.