### PR TITLE
Thor VIC actmon load, SYSFS polish, side-effect Orin ENGINE crash fix

### DIFF
--- a/jtop/gui/lib/linear_gauge.py
+++ b/jtop/gui/lib/linear_gauge.py
@@ -88,8 +88,13 @@ def basic_gauge(stdscr, pos_y, pos_x, size_w, data, bar='|'):
 def basic_gauge_simple(stdscr, pos_y, pos_x, size, freq_data, unit='k'):
     # Name gauge
     name = freq_data['name'] if 'name' in freq_data else ""
-    # Current value in string
-    curr_string = unit_to_string(freq_data['cur'], unit, 'Hz')
+    # Current value in string (may be missing on some Jetson variants)
+    cur_val = freq_data.get('cur')
+    try:
+        curr_string = unit_to_string(int(cur_val), unit, 'Hz') if cur_val is not None else "N/A"
+    except (TypeError, ValueError):
+        curr_string = "N/A"
+    online = freq_data.get('online', cur_val is not None)
     # Draw name engine
     stdscr.addstr(pos_y, pos_x, name, NColors.cyan())
     # Write online bar
@@ -97,8 +102,8 @@ def basic_gauge_simple(stdscr, pos_y, pos_x, size, freq_data, unit='k'):
     start_bar = pos_x + len(name) + 1 if len(name) > 0 else pos_x
     end_bar = start_bar + size_bar
     # Check if there is a limit
-    color_bar = NColors.green() if freq_data['online'] else NColors.red()
-    if freq_data['online']:
+    color_bar = NColors.green() if online else NColors.red()
+    if online:
         stdscr.hline(pos_y, start_bar + 1, curses.ACS_HLINE, size_bar)
         stdscr.addch(pos_y, start_bar + size_bar, curses.ACS_DIAMOND, curses.A_BOLD)
         if size_bar > 7:

--- a/jtop/gui/pengine.py
+++ b/jtop/gui/pengine.py
@@ -159,8 +159,15 @@ def draw_thor_engines_from_stats(stdscr, pos_y, pos_x, width, jetson, stats: dic
         try:
             vi = int(v)
         except (TypeError, ValueError):
-            return "IDLE"
-        return unit_to_string(vi, 'k', 'Hz') if vi > 0 else "IDLE"
+            vi = 0
+        base = unit_to_string(vi, 'k', 'Hz') if vi > 0 else "IDLE"
+        # VIC has an actmon-derived load% (Thor). Show it alongside the freq
+        # so idle-vs-busy is visible even when the clock is parked.
+        if key == "VIC" and isinstance(flat, dict):
+            load = flat.get("VIC_LOAD")
+            if isinstance(load, (int, float)):
+                return "{}  ({:.1f}% load)".format(base, float(load))
+        return base
 
     def _print_safe(row_y: int, col_x: int, text: str, attr=0):
         try:

--- a/jtop/gui/psysfs.py
+++ b/jtop/gui/psysfs.py
@@ -19,6 +19,7 @@ import curses
 import logging
 import os
 import re
+import time
 from glob import glob
 
 from .jtopgui import Page
@@ -39,6 +40,12 @@ _RE_MODE = re.compile(r"<\s*POWER_MODEL\s+ID=(\d+)\s+NAME=(\w+)\s*>")
 # Codecs on Thor (tegra264) share this devfreq clock domain
 _SHARED_CODEC_DEVFREQ = "gpu-nvd-0"
 _SHARED_CODEC_NOTE = "shared: nvdec/nvenc/nvjpg"
+
+# GUI draws at 20 Hz; without throttling, panels that read multiple sysfs files
+# per draw cost 100+ syscalls/s each. Cache reads so slow-changing values like
+# fan tach (kernel-averaged over ~1s) and rail current don't get re-read every
+# 50 ms. 250 ms → 4 Hz effective refresh.
+_SLOW_CACHE_TTL = 0.25
 
 # Prettier display names for common nvpmodel PARAM identifiers.
 # Unknown params fall through to their raw name from the conf.
@@ -93,6 +100,10 @@ def _bar(fraction, width=10):
         return "[" + " " * width + "]"
     f = max(0.0, min(1.0, fraction))
     filled = int(round(f * width))
+    # Sub-cell activity: show a dot when there's any load but not enough to fill
+    # half a cell (i.e. would otherwise round to 0). Half-cell+ rounds to a full |.
+    if filled == 0 and f > 0:
+        return "[." + " " * (width - 1) + "]"
     return "[" + "|" * filled + " " * (width - filled) + "]"
 
 
@@ -172,6 +183,11 @@ class SYSFS(Page):
 
     def __init__(self, stdscr, jetson):
         super(SYSFS, self).__init__("SYSFS", stdscr, jetson)
+        # Throttled read cache: path -> (value, monotonic_timestamp).
+        # Used by _cached_int/_cached_str in panels where sub-second updates
+        # aren't meaningful (rails, fans). OC counters and devfreq still read
+        # live because their deltas / cur values are interesting frame-to-frame.
+        self._cache = {}
         # Panel 1 — soctherm_oc: baseline is captured at jtop start; last is
         # updated each draw so we can tell "fired since jtop start" (history)
         # apart from "fired since last refresh" (live event).
@@ -214,6 +230,24 @@ class SYSFS(Page):
             if v is not None:
                 out[os.path.basename(p)] = v
         return out
+
+    def _cached_int(self, path):
+        now = time.monotonic()
+        entry = self._cache.get(path)
+        if entry is not None and (now - entry[1]) < _SLOW_CACHE_TTL:
+            return entry[0]
+        v = _read_int(path)
+        self._cache[path] = (v, now)
+        return v
+
+    def _cached_str(self, path):
+        now = time.monotonic()
+        entry = self._cache.get(path)
+        if entry is not None and (now - entry[1]) < _SLOW_CACHE_TTL:
+            return entry[0]
+        v = _read_str(path)
+        self._cache[path] = (v, now)
+        return v
 
     def _safe_addstr(self, y, x, text, attr=0):
         try:
@@ -308,14 +342,18 @@ class SYSFS(Page):
             self._safe_addstr(y, 3, "no /sys/class/devfreq entries", curses.A_DIM)
             return y + 1
 
-        self._safe_addstr(y, 3, "{:<22} {:>10} {:>10} {:>10}   note".format(
-            "NODE", "cur", "min", "max"), curses.A_DIM)
+        has_notes = any(os.path.basename(n) == _SHARED_CODEC_DEVFREQ for n in self._devfreq_nodes)
+        header = "{:<22} {:>10} {:>10} {:>10}  {:<16}".format("NODE", "cur", "min", "max", "gov")
+        if has_notes:
+            header += "  note"
+        self._safe_addstr(y, 3, header, curses.A_DIM)
         y += 1
         for node in self._devfreq_nodes:
             name = os.path.basename(node)
             cur = _read_int(os.path.join(node, "cur_freq"))
             mn = _read_int(os.path.join(node, "min_freq"))
             mx = _read_int(os.path.join(node, "max_freq"))
+            gov = _read_str(os.path.join(node, "governor")) or "?"
 
             # Color cur based on where it sits between min and max
             cur_attr = 0
@@ -324,16 +362,32 @@ class SYSFS(Page):
             elif cur is not None and mn is not None and cur <= mn:
                 cur_attr = NColors.cyan()                            # idle/floor
 
-            # Emit prefix, then cur with color, then rest
+            # Governor color: performance = forced max (yellow),
+            # tegra_wmark = actmon-driven DVFS (cyan), others dim.
+            if gov == "performance":
+                gov_attr = NColors.yellow() | curses.A_BOLD
+            elif gov == "tegra_wmark":
+                gov_attr = NColors.cyan()
+            else:
+                gov_attr = curses.A_DIM
+
+            # Emit prefix, then cur with color, then rest, then governor colored
             prefix = "{:<22} ".format(name[:22])
             cur_str = "{:>10}".format(_fmt_freq(cur))
-            rest = " {:>10} {:>10}   ".format(_fmt_freq(mn), _fmt_freq(mx))
+            mid = " {:>10} {:>10}  ".format(_fmt_freq(mn), _fmt_freq(mx))
+            gov_str = "{:<16}".format(gov[:16])
             note = _SHARED_CODEC_NOTE if name == _SHARED_CODEC_DEVFREQ else ""
-            self._safe_addstr(y, 3, prefix)
-            self._safe_addstr(y, 3 + len(prefix), cur_str, cur_attr)
-            self._safe_addstr(y, 3 + len(prefix) + len(cur_str), rest)
+            x = 3
+            self._safe_addstr(y, x, prefix)
+            x += len(prefix)
+            self._safe_addstr(y, x, cur_str, cur_attr)
+            x += len(cur_str)
+            self._safe_addstr(y, x, mid)
+            x += len(mid)
+            self._safe_addstr(y, x, gov_str, gov_attr)
+            x += len(gov_str) + 2
             if note:
-                self._safe_addstr(y, 3 + len(prefix) + len(cur_str) + len(rest), note, NColors.cyan())
+                self._safe_addstr(y, x, note, NColors.cyan())
             y += 1
         return y + 1
 
@@ -355,21 +409,21 @@ class SYSFS(Page):
 
         if self._ina3221:
             for ch in (1, 2, 3):
-                label = _read_str(os.path.join(self._ina3221, "in{}_label".format(ch)))
+                label = self._cached_str(os.path.join(self._ina3221, "in{}_label".format(ch)))
                 if not label:
                     continue
-                cur = _read_int(os.path.join(self._ina3221, "curr{}_input".format(ch)))
-                mx = _read_int(os.path.join(self._ina3221, "curr{}_max".format(ch)))
+                cur = self._cached_int(os.path.join(self._ina3221, "curr{}_input".format(ch)))
+                mx = self._cached_int(os.path.join(self._ina3221, "curr{}_max".format(ch)))
                 y = self._draw_rail_ma(y, label, cur, mx)
         else:
             self._safe_addstr(y, 3, "ina3221 not present", curses.A_DIM)
             y += 1
 
         if self._ina238:
-            p_uw = _read_int(os.path.join(self._ina238, "power1_input"))
-            p_max_uw = _read_int(os.path.join(self._ina238, "power1_max"))
-            v_mv = _read_int(os.path.join(self._ina238, "in1_input"))
-            t_mc = _read_int(os.path.join(self._ina238, "temp1_input"))
+            p_uw = self._cached_int(os.path.join(self._ina238, "power1_input"))
+            p_max_uw = self._cached_int(os.path.join(self._ina238, "power1_max"))
+            v_mv = self._cached_int(os.path.join(self._ina238, "in1_input"))
+            t_mc = self._cached_int(os.path.join(self._ina238, "temp1_input"))
             extra = ""
             if v_mv is not None:
                 extra = "bus {:.1f} V".format(v_mv / 1000.0)
@@ -394,44 +448,64 @@ class SYSFS(Page):
             self._safe_addstr(y, 3, "no PWM controllers or tachometers found", curses.A_DIM)
             return y + 1
 
+        # Compute shared column widths so PWM and TACH rows align.
+        # Frame: "<TYPE:4> <name:name_w>  (<hname>)"
+        type_w = 4  # "TACH" is 4
+        name_w = 3
+        hn_w = 0
+        for hname, pwm_path, _ in self._pwms:
+            name_w = max(name_w, len(os.path.basename(pwm_path)))
+            hn_w = max(hn_w, len(hname))
+        for hname, tach_path in self._tachs:
+            name_w = max(name_w, len(os.path.basename(tach_path)))
+            hn_w = max(hn_w, len(hname))
+        label_w = type_w + 1 + name_w + 2 + hn_w + 2  # +2 for the "()"
+        bar_col = 3 + label_w + 1
+        stats_col = bar_col + 14  # bar renders as "[" + 12 + "]" = 14 chars
+
+        def _fmt_label(kind, name, hname):
+            return "{:<{tw}} {:<{nw}}  ({})".format(kind, name, hname, tw=type_w, nw=name_w)
+
         # PWMs
         for hname, pwm_path, en_path in self._pwms:
-            raw = _read_int(pwm_path)
-            en = _read_int(en_path) if en_path else None
+            raw = self._cached_int(pwm_path)
+            en = self._cached_int(en_path) if en_path else None
             en_map = {0: "disabled", 1: "userspace", 2: "kernel-auto"}
             en_txt = en_map.get(en, "en={}".format(en)) if en is not None else "n/a"
             pct = (raw / 255.0 * 100.0) if raw is not None else None
-            label = "PWM {} ({})".format(os.path.basename(pwm_path), hname)
+            self._safe_addstr(y, 3, "{:<{w}}".format(_fmt_label("PWM", os.path.basename(pwm_path), hname), w=label_w))
             if raw is None:
-                self._safe_addstr(y, 3, "{:<23} n/a".format(label[:23]))
+                self._safe_addstr(y, bar_col, "n/a")
             else:
+                self._safe_addstr(y, bar_col, _bar(pct / 100.0 if pct else 0, 12), _bar_color(pct / 100.0 if pct else 0))
                 stats = " {:>3d}/255  ({:>5.1f}%)  mode: ".format(raw, pct or 0.0)
-                self._safe_addstr(y, 3, "{:<23} ".format(label[:23]))
-                self._safe_addstr(y, 3 + 24, _bar(pct / 100.0 if pct else 0, 12), _bar_color(pct / 100.0 if pct else 0))
-                self._safe_addstr(y, 3 + 24 + 14, stats)
+                self._safe_addstr(y, stats_col, stats)
                 # 0=disabled (nothing driving fan), 1=userspace (nvfancontrol on Thor), 2=kernel driver
                 mode_attr = NColors.red() | curses.A_BOLD if en == 0 else \
                     (NColors.green() if en == 1 else NColors.yellow())
-                self._safe_addstr(y, 3 + 24 + 14 + len(stats), en_txt, mode_attr)
+                self._safe_addstr(y, stats_col + len(stats), en_txt, mode_attr)
             y += 1
 
         # Tachometers
         for hname, tach_path in self._tachs:
-            rpm = _read_int(tach_path)
+            rpm = self._cached_int(tach_path)
             fname = os.path.basename(tach_path)
-            label = "TACH {} ({})".format(fname, hname)
+            self._safe_addstr(y, 3, "{:<{w}}".format(_fmt_label("TACH", fname, hname), w=label_w))
             if rpm is None:
-                self._safe_addstr(y, 3, "{:<23} n/a".format(label[:23]))
+                self._safe_addstr(y, stats_col, "n/a")
             else:
                 # Stuck-fan warning: only meaningful when we can unambiguously
                 # pair a tach with a PWM. We don't attempt matching by path
                 # (on Thor PWM and tach live in different hwmons), so restrict
                 # the check to the 1-PWM / 1-tach case common on Jetson devkits.
                 warn = (rpm == 0 and len(self._pwms) == 1 and len(self._tachs) == 1 and
-                        (_read_int(self._pwms[0][1]) or 0) > 0)
+                        (self._cached_int(self._pwms[0][1]) or 0) > 0)
                 attr = NColors.red() | curses.A_BOLD if warn else NColors.green()
                 suffix = "  (PWM>0 but no rotation)" if warn else ""
-                self._safe_addstr(y, 3, "{:<23} {:>6d} RPM{}".format(label[:23], rpm, suffix), attr)
+                # {:>7d} aligns the number's last digit under the last '5' of
+                # "N/255" in the PWM row (leading space + {:>3d}/255 = 8 chars).
+                # 3 spaces before "RPM" places it under the "(30.2%)" column.
+                self._safe_addstr(y, stats_col, " {:>7d}   RPM{}".format(rpm, suffix), attr)
             y += 1
         return y + 1
 

--- a/jtop/gui/psysfs.py
+++ b/jtop/gui/psysfs.py
@@ -566,8 +566,16 @@ class SYSFS(Page):
         y += 1
         for pname in ordered:
             conf_v = _cap_from_mode(active, pname, "MAX_FREQ")
-            live_path = self._nvp_params[pname].get("MAX_FREQ")
-            live_v = _read_int(live_path) if live_path else None
+            # Newer Orin kernels (K-next) only wire the _KNEXT paths; the plain
+            # MAX_FREQ paths in nvpmodel.conf point at legacy locations that
+            # don't exist. Prefer KNEXT when readable, fall back to legacy.
+            live_v = None
+            for key in ("MAX_FREQ_KNEXT", "MAX_FREQ"):
+                p = self._nvp_params[pname].get(key)
+                if p:
+                    live_v = _read_int(p)
+                    if live_v is not None:
+                        break
             if conf_v is None and live_v is None:
                 continue  # nothing to say about this domain in this mode
             mark = ""

--- a/jtop/service.py
+++ b/jtop/service.py
@@ -91,6 +91,46 @@ JTOP_SERVICE_NAME = 'jtop.service'
 TIMEOUT_GAIN = 3
 TIMEOUT_SWITCHOFF = 3.0
 
+# VIC actmon load node (Thor). Documented at
+# https://docs.nvidia.com/jetson/archives/r39.2.1/DeveloperGuide/SD/PlatformPowerAndPerformance/JetsonThor.html#multimedia-engine-power-management
+# The doc names "tegra-host1x.0" but the shipping Thor kernel exposes it under
+# "tegra-host1x" (no .0). Try both — first hit wins.
+_VIC_ACTMON_USAGE_CANDIDATES = (
+    "/sys/kernel/debug/tegra-host1x.0/actmon/vic/module0/usage",
+    "/sys/kernel/debug/tegra-host1x/actmon/vic/module0/usage",
+)
+
+
+def _read_vic_actmon_load():
+    """Return VIC actmon load as a float percent (0..100), or None if unavailable.
+
+    Requires debugfs read access (jtop service runs as root). Silent on failure
+    so non-Thor systems and kernels without the node are unaffected.
+
+    Unit note: on the shipping Thor kernel the `usage` node reports permille
+    (0..1000), matching the default `tegra_wmark/load_target=100` == 10%.
+    Some older Tegra actmon drivers report percent (0..100). Values > 100 are
+    treated as permille and divided by 10 to normalize to percent.
+    """
+    for path in _VIC_ACTMON_USAGE_CANDIDATES:
+        try:
+            with open(path) as fh:
+                raw = fh.read().strip()
+        except OSError:
+            continue
+        raw = raw.rstrip("%").strip()
+        try:
+            v = int(raw)
+        except ValueError:
+            return None
+        pct = v / 10.0 if v > 100 else float(v)
+        if pct < 0.0:
+            pct = 0.0
+        elif pct > 100.0:
+            pct = 100.0
+        return pct
+    return None
+
 
 def overlay_jetsonpower_flat(
     data: Dict[str, Any],
@@ -765,6 +805,16 @@ class JtopServer(Process):
                         cur = eng_data.get("cur")
                         if cur is not None:
                             flat[eng_name] = cur
+
+            # VIC actmon load — Thor exposes real-time VIC utilization via
+            # debugfs. tegrastats reports "VIC off" so this is the only source.
+            vic_load = _read_vic_actmon_load()
+            if vic_load is not None:
+                flat["VIC_LOAD"] = vic_load
+                if isinstance(jp_group, dict):
+                    vic_entry = jp_group.setdefault("VIC", {})
+                    if isinstance(vic_entry, dict):
+                        vic_entry["load"] = vic_load
 
             # Canary marker (namespaced; never top-level)
             flat["JP_OVERLAY"] = 1

--- a/jtop/service.py
+++ b/jtop/service.py
@@ -107,10 +107,9 @@ def _read_vic_actmon_load():
     Requires debugfs read access (jtop service runs as root). Silent on failure
     so non-Thor systems and kernels without the node are unaffected.
 
-    Unit note: on the shipping Thor kernel the `usage` node reports permille
-    (0..1000), matching the default `tegra_wmark/load_target=100` == 10%.
-    Some older Tegra actmon drivers report percent (0..100). Values > 100 are
-    treated as permille and divided by 10 to normalize to percent.
+    Unit note: the shipping Thor kernel reports `usage` in permille (0..1000),
+    matching the default `tegra_wmark/load_target=100` == 10%. Always divided
+    by 10 to normalize to percent.
     """
     for path in _VIC_ACTMON_USAGE_CANDIDATES:
         try:
@@ -122,8 +121,8 @@ def _read_vic_actmon_load():
         try:
             v = int(raw)
         except ValueError:
-            return None
-        pct = v / 10.0 if v > 100 else float(v)
+            continue
+        pct = v / 10.0
         if pct < 0.0:
             pct = 0.0
         elif pct > 100.0:


### PR DESCRIPTION
## Summary
  - Add Thor VIC actmon load reader (service.py) and surface it on the ENGINE tab as `VIC <freq> (NN.N% load)`.
  - Fix Orin crash: `basic_gauge_simple` KeyError on engines that lack `cur`/`online` (freq_gauge fallback path).
  - SYSFS panel polish: DEVFREQ gov column, sub-half-cell "." bar fill, aligned PWM/TACH columns, and a 250 ms sysfs read cache so 20 Hz GUI redraws don't hammer sysfs.

  ## Files modified
  - service.py: read /sys/kernel/debug/tegra-host1x{,.0}/actmon/vic/module0/usage (kernel exposes without .0; value is permille) and publish VIC_LOAD into data["flat"] and data["engines"]["JP"]["VIC"]["load"].
  - pengine.py: Thor ENGINE tab shows "VIC <freq> (NN.N% load)" when actmon reports a value; falls back to bare freq/IDLE otherwise.
  - linear_gauge.py: basic_gauge_simple() no longer KeyErrors on missing 'cur'/'online' (Orin engines that lack cur/min/max hit the freq_gauge fallback path and crashed the ENG tab).
  - psysfs.py:
    - DEVFREQ: add "gov" column between max and note; performance=yellow, tegra_wmark=cyan, others dim. Hide "note" header on Orin (only Thor's shared codec devfreq emits it).
    - Bars: show a "." for sub-half-cell fill so low-load rails/fans are visibly non-zero instead of empty.
    - FANS: align PWM and TACH rows on shared (type, name, hwmon) columns, and align the RPM number's last digit under the last digit of N/255.
    - Cache POWER RAILS and FANS sysfs reads with a 250 ms TTL so the 20 Hz GUI redraw doesn't hammer sysfs at 100+ syscalls/sec.

  ## Tested and passed on AGX Orin and Thor.
  - [x] Thor: VIC load shows under nvvidconv stress (0% idle → ~30% at 8K→FHD), governor tegra_wmark parks the clock as expected.
  - [x] Thor: ENGINE, SYSFS, FANS panels render; bar shows `.` at low load.
  - [x] Orin: ENGINE tab no longer crashes; freq_gauge falls back cleanly when engines lack min/max/cur.
  - [x] Orin: SYSFS panel — note column hidden (no shared codec devfreq), RPM aligns under N/255, cached reads make idle updates calm.

<!---
Thanks for your contribution!

If this is your first PR to jetson-stats please review the Contributing Guide:
https://rnext.it/jetson_stats/contributing.html

Adhering to the Contributing Guide means we can review, merge, and release your change faster! :)
--->

## Summary by Sourcery

Improve Jetson engine monitoring and SYSFS presentation across Thor and Orin platforms.

New Features:
- Expose Thor VIC utilization in the ENGINE panel alongside its current frequency.

Bug Fixes:
- Prevent ENGINE panel crashes on Orin systems when engine frequency metadata is incomplete.

Enhancements:
- Polish SYSFS devfreq, activity bars, and fan-monitor layouts for clearer status presentation.
- Throttle slow SYSFS rail and fan reads to reduce overhead during frequent GUI refreshes.
- Improve live nvpmodel frequency reporting on newer Orin kernels.