### PR TITLE
feat(thor,psysfs): pynvml per-block codec utilization panel

### DIFF
--- a/jtop/core/thor_gpu.py
+++ b/jtop/core/thor_gpu.py
@@ -137,6 +137,59 @@ def nvml_process_table() -> Tuple[int, List]:
     return total_kb, rows
 
 
+# 1-second TTL cache for the codec-utilization probe. SYSFS tab redraws
+# frequently; NVML per-tick would be wasteful and racy against the process
+# table calls that also grab an NVML handle.
+_CODEC_UTIL_CACHE: Dict[str, Any] = {"ts": 0.0, "data": None}
+
+
+def nvml_codec_utilization() -> Optional[Dict[str, Tuple[int, int]]]:
+    """
+    Per-block codec utilization from NVML on Jetson.
+
+    Returns {'encoder': (util%, sample_period_us), 'decoder': (...), 'jpg': (...), 'ofa': (...)}
+    or None if NVML isn't available / init fails.  Individual blocks that
+    report NotSupported are omitted from the dict.
+
+    Disambiguates the Thor shared codec clock (`gpu-nvd-0` gates NVDEC/NVENC/NVJPG
+    together) — the clock alone can't tell you which block is active, but these
+    per-block util % can.
+    """
+    global _CODEC_UTIL_CACHE
+    now = time.monotonic()
+    if now - _CODEC_UTIL_CACHE["ts"] < 1.0:
+        return _CODEC_UTIL_CACHE["data"]
+
+    if not _NVML:
+        _CODEC_UTIL_CACHE = {"ts": now, "data": None}
+        return None
+
+    try:
+        _pynvml.nvmlInit()
+        h = _pynvml.nvmlDeviceGetHandleByIndex(0)
+    except _pynvml.NVMLError as e:
+        logger.debug("NVML init/handle failed for codec util: %s", e)
+        _CODEC_UTIL_CACHE = {"ts": now, "data": None}
+        return None
+
+    result: Dict[str, Tuple[int, int]] = {}
+    for key, getter in (
+        ("encoder", _pynvml.nvmlDeviceGetEncoderUtilization),
+        ("decoder", _pynvml.nvmlDeviceGetDecoderUtilization),
+        ("jpg", _pynvml.nvmlDeviceGetJpgUtilization),
+        ("ofa", _pynvml.nvmlDeviceGetOfaUtilization),
+    ):
+        try:
+            util, period = getter(h)
+            result[key] = (int(util), int(period))
+        except _pynvml.NVMLError:
+            pass
+
+    data = result if result else None
+    _CODEC_UTIL_CACHE = {"ts": now, "data": data}
+    return data
+
+
 def nvml_gpu_used_kb() -> Optional[int]:
     """
     Cached (1-second TTL) sum of GPU process memory from NVML (in kB).

--- a/jtop/gui/psysfs.py
+++ b/jtop/gui/psysfs.py
@@ -24,6 +24,13 @@ from glob import glob
 from .jtopgui import Page
 from .lib.colors import NColors
 
+# Optional: per-block codec utilization via NVML (Thor + Orin w/ nvidia-ml-py).
+# Panel simply hides if unavailable.
+try:
+    from ..core.thor_gpu import nvml_codec_utilization
+except Exception:
+    nvml_codec_utilization = None
+
 logger = logging.getLogger(__name__)
 
 _HWMON = "/sys/class/hwmon"
@@ -337,6 +344,44 @@ class SYSFS(Page):
             y += 1
         return y + 1
 
+    def _draw_codec(self, y, _width):
+        if nvml_codec_utilization is None:
+            return y
+        util = nvml_codec_utilization()
+        if not util:
+            return y
+        y = self._panel_header(y, "CODEC UTILIZATION (NVML)")
+        # Single row inline: NVENC 0%   NVDEC 0%   NVJPG 0%   OFA 0%   (window 1.0 ms)
+        # Compact because SYSFS already has 5 panels — vertical space is at a premium.
+        x = 3
+        period_us = None
+        for key, label in (("encoder", "NVENC"), ("decoder", "NVDEC"),
+                           ("jpg", "NVJPG"), ("ofa", "OFA")):
+            if key not in util:
+                continue
+            pct, p = util[key]
+            if period_us is None:
+                period_us = p
+            # 0% is dim; above that, escalate green→cyan→yellow-bold
+            if pct <= 0:
+                attr = curses.A_DIM
+            elif pct < 50:
+                attr = NColors.green()
+            elif pct < 80:
+                attr = NColors.cyan()
+            else:
+                attr = NColors.yellow() | curses.A_BOLD
+            self._safe_addstr(y, x, "{} ".format(label))
+            x += len(label) + 1
+            val = "{:d}%".format(pct)
+            self._safe_addstr(y, x, val, attr)
+            x += len(val) + 3
+        if period_us is not None:
+            window = "(window {:.1f} ms)".format(period_us / 1000.0) if period_us >= 1000 \
+                else "(window {:d} us)".format(period_us)
+            self._safe_addstr(y, x, window, curses.A_DIM)
+        return y + 2
+
     def _draw_rail_ma(self, y, label, curr_ma, max_ma):
         if curr_ma is None:
             self._safe_addstr(y, 3, "{:<18} n/a".format(label))
@@ -516,6 +561,7 @@ class SYSFS(Page):
         y = first + 2  # blank line under Model header
         y = self._draw_throttle(y, width)
         y = self._draw_devfreq(y, width)
+        y = self._draw_codec(y, width)
         y = self._draw_rails(y, width)
         y = self._draw_fans(y, width)
         y = self._draw_nvpmodel(y, width)


### PR DESCRIPTION
- jtop/core/thor_gpu.py — new nvml_codec_utilization() returning {encoder, decoder, jpg, ofa} with 1s TTL cache
- jtop/gui/psysfs.py — new _draw_codec() compact single-line panel (NVENC 0%   NVDEC 0%   NVJPG 0%   OFA 0%)
  between devfreq and rails; auto-hides if NVML unavailable.

- Tested: Thor displays Codec Utilization. Orin cannot:
  On Thor the codec engines are exposed as blocks of the discrete-style GPU that NVML manages, so NvmlDeviceGet{Enc,Dec,Jpg,Ofa}Utilization return real data. On Orin the codec engines are separate host1x IPs (each with its own devfreq node:  gpu-nvd-0 for NVDEC, plus NVENC/NVJPG nodes), not children of the NVML-managed GPU — the NVML API just doesn't have a hook to their actmons.

## Summary by Sourcery

Expose Thor codec-engine utilization in the SYSFS dashboard through NVML.

New Features:
- Add a SYSFS panel showing per-block NVENC, NVDEC, NVJPG, and OFA utilization when NVML provides the data.

Enhancements:
- Cache codec utilization readings for one second and hide the panel when NVML or individual codec metrics are unavailable.